### PR TITLE
Updating the RPM spec file to no longer look for the auto_cert_kit.py file

### DIFF
--- a/xenserver-auto-cert-kit.spec.in
+++ b/xenserver-auto-cert-kit.spec.in
@@ -32,7 +32,6 @@ exit 0
 
 %files
 %defattr(-,root,root,-)
-/opt/xensource/packages/files/auto-cert-kit/auto_cert_kit.py
 /opt/xensource/packages/files/auto-cert-kit/cpu_tests.py
 /opt/xensource/packages/files/auto-cert-kit/network_tests.py
 /opt/xensource/packages/files/auto-cert-kit/operations_tests.py


### PR DESCRIPTION
The file was erroneously removed as part of the move to using github. The spec file was not updated.
