### PR TITLE
CA-100387: MTU test case directs ping at eth0 not eth1

### DIFF
--- a/kit/network_tests.py
+++ b/kit/network_tests.py
@@ -742,7 +742,7 @@ class MTUPingTestClass(testbase.NetworkTestClass):
 
         log.debug("Ping Arguments: %s" % self.PING_ARGS)
         #set ping args and run cmd
-        ping_result = ping(vm1_ip, vm2_ip, 'eth1', self.PING_ARGS['packet_size'], self.PING_ARGS['packet_count'])
+        ping_result = ping(vm1_ip, vm2_ip_eth1, 'eth1', self.PING_ARGS['packet_size'], self.PING_ARGS['packet_count'])
         log.debug("Result: %s" % ping_result)
             
             


### PR DESCRIPTION
CA-100387: In recent modifications to the ACK to ensure we separated test from management interfaces on VM tests the MTU test case was not updated to direct its ping at eth1 on the destination VM. This patch fixes that problem.
