### PR TITLE
Fix for -i option in ack_cli.py command.

### DIFF
--- a/kit/test_generators.py
+++ b/kit/test_generators.py
@@ -247,8 +247,8 @@ def print_documentation(object_name):
             print utils.format(test_class.__doc__)
             print ""
             print "%s:" % (utils.bold('Tests'))
-            for method in [m for m in dir(test_class)
-                if callable(getattr(test_class, m)) and m.startswith('test')]:
+            inst = test_class(None, {})
+            for method in inst.list_tests():
                 print method
             print ""
             sys.exit(0)


### PR DESCRIPTION
A quick fix for ack_cli.py -i option that prints out information of the test.
an unassinged var 'self' is being used.
