### PR TITLE
CA-107639: Lowering the acceptance bar for bonding failover to allow pac...

### DIFF
--- a/kit/network_tests.py
+++ b/kit/network_tests.py
@@ -555,9 +555,11 @@ class BondingTestClass(testbase.NetworkTestClass):
         rec['config'] = mode
        
         for result in results:
-            if "0% packet loss" not in result:
+            if not valid_ping_response(result, 20):
                 raise TestCaseError("Error: Ping transmittion failed for bond type: %s. %s" 
-                                    % (mode, result))     
+                                    % (mode, result))
+            else:
+                log.debug("Ping Result: %s" % result)
                 
         return rec
     

--- a/kit/utils.py
+++ b/kit/utils.py
@@ -44,6 +44,7 @@ import signal
 import os
 import base64
 import threading
+import re
 
 K = 1024
 M = 1024 * K
@@ -1972,3 +1973,23 @@ def check_vm_ping_response(session, vm_ref, interface='eth0', count=3, timeout=3
         time.sleep(3)
     
     raise Exception("VM %s interface %s could not be reached in the given timeout" % (vm_ref, interface))
+
+def valid_ping_response(ping_response, max_loss=0):
+
+    if max_loss > 100:
+        raise Exception("Error: cannot have a loss of > 100%!")
+
+    regex = re.compile(r"(?P<loss>\d+)\% packet loss")
+    match = regex.search(ping_response)
+    if match:
+        # We've matched the regex for the ping result, now we
+        # check whether the number of packets lost is acceptable.
+        loss = int(match.group('loss'))
+        return loss <= max_loss
+    else:
+        # We did not match the ping output, therefore we cannot
+        # validate the response.    
+        return False
+
+
+

--- a/tests/unit_utils.py
+++ b/tests/unit_utils.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 
 sys.path.append('../kit/')
-from utils import value_in_range, wrapped_value_in_range
+from utils import value_in_range, wrapped_value_in_range, valid_ping_response
 
 K = 1024
 M = K * 1024
@@ -35,6 +35,20 @@ class ValueInRangeFunctions(unittest.TestCase):
                                                8248029658,
                                                9067544228))
 
+
+class ValidatePingResponses(unittest.TestCase):
+
+    def test_valid_ping_responses(self):
+        response = "20 packets transmitted, 19 received, 5% packet loss, time 19008ms"
+        self.assertTrue(valid_ping_response(response, max_loss=20))
+
+    def test_invalid_ping_responses(self):
+        response = "20 packets transmitted, 19 received, 5% packet loss, time 19008ms"
+        self.assertFalse(valid_ping_response(response, max_loss=0))
+
+    def test_valid_equal_ping_responses(self):
+        response = "20 packets transmitted, 19 received, 5% packet loss, time 19008ms"
+        self.assertTrue(valid_ping_response(response, max_loss=5))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
...ket loss upto 20%. This corresponds to 4 packets (~4 seconds to failover).

Signed-off-by: Rob Dobson rob@rdobson.co.uk
