### PR TITLE
Updated ACK source url.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 setup(name='AutoCertKit',
       version='0.8.1',
       author='Citrix System Inc.',
-      url='http://github.com/xen-org/auto-cert-kit',
+      url='http://github.com/xenserver/auto-cert-kit',
       packages=['autocertkit', 'XenAPI', 'acktools', 'acktools.net'],
      )
 


### PR DESCRIPTION
Auto Cert Kit is part of XenServer OSS and URL re-directs to .../xenserver/... anyway.
