### PR TITLE
Sometimes, 5 sec is not enough for ifconfig command.

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1814,7 +1814,7 @@ def set_nic_device_status(interface, status, creds=None):
                           creds['user'],
                           creds['pass'],
                           ' '.join(call))
-    time.sleep(5)
+    time.sleep(10)
     return res
 
 class TestThread(threading.Thread):


### PR DESCRIPTION
A irregular failure found in tampa LCM ACK run, that lost first a few packets in ping in bond_active_backup test case.
