### PR TITLE
Added PCI subsystem information in resutls.txt file.

### DIFF
--- a/autocertkit/models.py
+++ b/autocertkit/models.py
@@ -353,6 +353,12 @@ class Device(object):
         except Exception, e:
             log.error("Exception occurred getting ID: '%s'" % str(e))
         return "Unknown ID"
+
+    def get_subsystem(self):
+        """Return the information of PCI subsysem if it exists."""
+        if self.tag == "NA" and "PCI_subsystem" in self.config:
+            return self.config["PCI_subsystem"]
+        return ""
         
     def get_description(self):
         """Depending on the type, return the appropriate description
@@ -433,6 +439,9 @@ class Device(object):
         stream.write("\n")
         stream.write("Device ID: %s\n" % self.get_id())
         stream.write("Description: %s\n" % self.get_description())
+        subsystem = self.get_subsystem()
+        if subsystem and len(subsystem) > 0:
+            subsystem = stream.write("%s\n" % subsystem)
         stream.write("#########################\n\n")
 
         if not self.has_passed():

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -483,7 +483,19 @@ def get_pci_description(bus_id):
     vendor = IDS.findVendor(dev_rec['vendor'])
     description = IDS.findDevice(dev_rec['vendor'], dev_rec['device'])
     return "%s %s" % (vendor, description)
-        
+
+def get_pci_subsystem(bus_id):
+    """Return the PCI subsystem information for a specified bus location:"""
+    log.debug("Getting subsystem for PCI device at bus id: %s" % bus_id)
+    
+    call = ['/sbin/lspci', '-nn', '-v', '-s', bus_id]
+    try:
+        res = make_local_call(call)
+        return res["stdout"].split('\n')[1].strip()
+    except Exception, e:
+        log.debug("Exception: %s" % str(e))
+    return ""
+
 @log_exceptions
 def create_output_package(session, args):
     """Create an output package for submission to Citrix"""
@@ -560,6 +572,7 @@ def get_network_devices(session, args):
         device['PCI_id'] = pci_id
         log.debug("Bus Id %s" % device['Bus Info'])
         device['PCI_description'] = get_pci_description(device['Bus Info'])
+        device['PCI_subsystem'] = get_pci_subsystem(device['Bus Info'])
         devices.append(device)
 
     return list_to_xml(devices, 'device')


### PR DESCRIPTION
results.txt for ACK submission does not have subsystem information of PCI devices.
This adds subsystem information included in test result file and submission files.
