### PR TITLE
Change the way of managing static IPs

### DIFF
--- a/autocertkit/test_generators.py
+++ b/autocertkit/test_generators.py
@@ -168,7 +168,7 @@ class NetworkAdapterTestGenerator(TestGenerator):
     def prereq_check(self):
         if 'static' in self.config.keys():
             ip_manager = utils.StaticIPManager(self.config['static'])
-            num_ips_provided = len(ip_manager.free)
+            num_ips_provided = ip_manager.total_ips
 
             # Work out the maximum required number of IPs of tests
             # which are going to be run.

--- a/autocertkit/tests/utils_tests.py
+++ b/autocertkit/tests/utils_tests.py
@@ -90,7 +90,7 @@ class StaticIPUtilsTests(unittest_base.DevTestCase):
                      '10.80.227.151']
 
         sim = utils.StaticIPManager(conf)
-        free_list = sim.free
+        free_list = sim.ip_pool
 
         if len(free_list) != len(full_list):
             raise Exception("Error: we expect there to be %d IPs, enumerate produced %d." % 
@@ -110,12 +110,12 @@ class StaticIPUtilsTests(unittest_base.DevTestCase):
         sim = utils.StaticIPManager(conf)
 
         borrowed_ip = sim.get_ip()
-        assert(len(sim.free) == 5)
+        assert(sim.available_ips() == 5)
         assert(len(sim.in_use) == 1)
         
         sim.return_ip(borrowed_ip)
 
-        assert(len(sim.free) == 6)
+        assert(sim.available_ips() == 6)
         assert(len(sim.in_use) == 0)
 
         


### PR DESCRIPTION
Now StaticIPManager produces an unused IP first when it is available.
StaticIPManager also does not hold 'free' IPs and 'used' IPs, instead it only holds 'ip_pools' and indexes of IPs that are used.
New available_ips method is added onto StaticIPManager, which returns number of free IPs from pool.
