### PR TITLE
Fixed a bug that get_ip in static manager reaches out of index.

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -328,7 +328,7 @@ class StaticIPManager(object):
             raise Exception("Error: no more IP addresses to allocate! (%d in use)" %
                             len(self.in_use))
             
-        index = self.last_used + 1
+        index = (self.last_used + 1) % self.total_ips
         while True:
             if not index in self.in_use:
                 self.last_used = index


### PR DESCRIPTION
A bug is found on last commit.

If static ip pool is not big enough, then get_ip tries to obtain ip out of bound while it should search again from  index 0.
