### PR TITLE
CA-90564: Adding logrotate to ACK

### DIFF
--- a/autocertkit/test_runner.py
+++ b/autocertkit/test_runner.py
@@ -179,6 +179,14 @@ def run_tests_from_file(test_file):
     ack_model = models.parse_xml(test_file)
 
     config = ack_model.get_global_config()
+    
+    hosts = session.xenapi.host.get_all()
+    for host in hosts:
+        session.xenapi.host.call_plugin(host, 
+                                        'autocertkit',
+                                        'run_ack_logrotate', 
+                                        {})
+        log.debug("Running logrotate on host %s" % host)
 
     log.debug("ACK Model: %s" % ack_model.is_finished())
     while not ack_model.is_finished():

--- a/config/logrotate.conf
+++ b/config/logrotate.conf
@@ -1,0 +1,11 @@
+compress
+/var/log/auto-cert-kit.log {
+        rotate 50
+        size 10M
+        missingok
+}
+/var/log/auto-cert-kit-plugin.log {
+        rotate 50
+        size 10M
+        missingok
+}

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -39,6 +39,7 @@ import XenAPIPlugin
 import subprocess
 import xmlrpclib
 import os, sys
+import shutil
 import time
 import logging
 import logging.handlers
@@ -74,6 +75,7 @@ IPERF = '/usr/bin/iperf'
 DROID_VM_LOC = '%s/vpx-dlvm.xva' % INSTALL_DIR
 XS_INVENTORY_PATH = "/etc/xensource-inventory"
 LMBENCH_CONF_LOC = "%s/config/lmbench.conf" % INSTALL_DIR
+LOGROTATE_CONF_LOC = "%s/config/logrotate.conf" % INSTALL_DIR
 FOR_CLEANUP = "for_cleanup"
 SSH = "/usr/bin/ssh"
 IP = "/sbin/ip"
@@ -357,6 +359,18 @@ def save_bugtool():
     log.debug("Bugtool saved: %s" % bugtool_loc)
     return bugtool_loc
 
+def run_ack_logrotate(session, args):
+    """Run logrotate for ACK logs"""
+    ack_logrotate_dconf = '/etc/logrotate.d/autocertkit'
+
+    try:
+        shutil.copyfile(LOGROTATE_CONF_LOC, ack_logrotate_dconf)
+        call = ['/usr/sbin/logrotate', '-f', ack_logrotate_dconf]
+        res = make_local_call(call)['stdout']
+    except Exception, e:
+        res = str(e)
+        log.debug("Exception: %s" % res)
+    return res
 
 ############### IPERF Setup #########################
 
@@ -1587,5 +1601,5 @@ if __name__ == '__main__':
                            'get_local_device_ip': get_local_device_ip,
                            'get_local_device_info': get_local_device_info,
                            'inject_ssh_key': inject_ssh_key,
-                           'get_kernel_version': get_kernel_version
-                           })
+                           'get_kernel_version': get_kernel_version,
+                           'run_ack_logrotate': run_ack_logrotate})

--- a/xenserver-auto-cert-kit.spec.in
+++ b/xenserver-auto-cert-kit.spec.in
@@ -50,6 +50,7 @@ rm -rf %{buildroot}
 /opt/xensource/packages/files/auto-cert-kit/make-3.81-3.el5.i386.rpm
 /opt/xensource/packages/files/auto-cert-kit/networkconf.example
 /opt/xensource/packages/files/auto-cert-kit/config/lmbench.conf
+/opt/xensource/packages/files/auto-cert-kit/config/logrotate.conf
 /etc/xapi.d/plugins/autocertkit
 /etc/init.d/auto-cert-kit
 /etc/xensource/bugtool/Auto_Cert_Kit.xml


### PR DESCRIPTION
Executes logrotate on all hosts during start of an ACK run
