### PR TITLE
Release SIG_ALRM at the start of each tests.

### DIFF
--- a/autocertkit/testbase.py
+++ b/autocertkit/testbase.py
@@ -32,6 +32,7 @@
 
 import traceback
 import re
+import signal
 from utils import *
 log = get_logger('auto-cert-kit')
 
@@ -98,7 +99,11 @@ class TestClass(object):
             # This assumes that we do not keep IPs across individual tests
             for vlan, sm in self.static_managers.iteritems():
                 sm.release_all()
-                
+
+            # Release Alarm signal to prevent handled signal from previous test
+            # interrupts this test. When there is no SIG_ALRM, this does nothing.
+            signal.alarm(0)
+
             # Ensure that we cleanup before running tests, in case
             # the system has been left in a failed state. 
             pool_wide_cleanup(self.session)


### PR DESCRIPTION
To prevent SIG_ALRM cause interruption to next test case, reset SIG_ALRM at the end of each tests, just before pool_wide_cleanup().
