### PR TITLE
change logrotate only run when ACK starts for the first time for conf.

### DIFF
--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -392,6 +392,14 @@ def main(config, test_run_file):
         utils.log.info("Test file generated")
         return "OK"
 
+    # Run log rotate before execute tests.
+    for host in session.xenapi.host.get_all():
+        utils.log.debug("Running logrotate on host %s" % host)
+        session.xenapi.host.call_plugin(host, 
+                                    'autocertkit',
+                                    'run_ack_logrotate', 
+                                    {})
+
     #Kick off the testrunner
     test_file, output = test_runner.run_tests_from_file(test_run_file)
 

--- a/autocertkit/test_runner.py
+++ b/autocertkit/test_runner.py
@@ -180,14 +180,6 @@ def run_tests_from_file(test_file):
 
     config = ack_model.get_global_config()
     
-    hosts = session.xenapi.host.get_all()
-    for host in hosts:
-        session.xenapi.host.call_plugin(host, 
-                                        'autocertkit',
-                                        'run_ack_logrotate', 
-                                        {})
-        log.debug("Running logrotate on host %s" % host)
-
     log.debug("ACK Model: %s" % ack_model.is_finished())
     while not ack_model.is_finished():
         log.debug("Test Run Status: P %d, F %d, W %d" % (ack_model.get_status()))


### PR DESCRIPTION
I advised to put the logrotate caller in test_runner.py and it was not the best advice.
'test_runner.py' can be called multiple time in single ACK run. Besides, there is no way to keep log files when we execute 'test_runner.py' after creating 'test_run.conf' with '-d' option. Hence removed it back to 'ack_cli.py'.
