### PR TITLE
Uncommented get_ack_version to function properly.

### DIFF
--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -378,9 +378,10 @@ def main(config, test_run_file):
     output file"""
     
     session = get_xapi_session(config)
-    config['xs_version'] = utils.get_xenserver_version(session)
 
     pre_flight_checks(session, config)
+
+    config['xs_version'] = utils.get_xenserver_version(session)
 
     generate_test_config(session, config, test_run_file)
     # Logout of XAPI session anyway - the test runner will create a new session

--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -2003,14 +2003,10 @@ def wait_for_hosts(session, timeout=300):
 
 def get_ack_version(session, host):
     """Return the version string corresponding to the cert kit on a particular host"""
-#    sw = session.xenapi.host.get_software_version(host)
-#    key = 'xs:xs-auto-cert-kit'
-#    if key in sw.keys():
-#        return sw[key]
-    if os.path.exists('/etc/xensource/installed-repos/xs:xs-auto-cert-kit'):
-        return True
-    else:
-        return None
+    sw = session.xenapi.host.get_software_version(host)
+    key = 'xs:xs-auto-cert-kit'
+    if key in sw.keys():
+        return sw[key]
 
 def combine_recs(rec1, rec2):
     """Utility function for combining two records into one."""


### PR DESCRIPTION
Now pre_flight_check() is the first function to call from ack_cli. To check
all hosts have the ACK installed.
