### PR TITLE
Fix a bug on re-initiating logger after running logrotate.

### DIFF
--- a/acktools/log.py
+++ b/acktools/log.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+
+# Copyright (c) Citrix Systems Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, 
+# with or without modification, are permitted provided 
+# that the following conditions are met:
+#
+# *   Redistributions of source code must retain the above 
+#     copyright notice, this list of conditions and the 
+#     following disclaimer.
+# *   Redistributions in binary form must reproduce the above 
+#     copyright notice, this list of conditions and the 
+#     following disclaimer in the documentation and/or other 
+#     materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# SUCH DAMAGE.
+
+
+import sys
+import logging
+import logging.handlers
+
+def configure_log(name, path, to_stdout=True):
+    log = logging.getLogger(name)
+    log.setLevel(logging.DEBUG)
+
+    try:
+        fileh = logging.FileHandler(path)
+        fileh.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%%(asctime)-8s %s: %%(levelname)-8s %%(filename)s:%%(lineno)-10d %%(message)s' % name)
+        fileh.setFormatter(formatter)
+        log.addHandler(fileh)
+        log.debug("Start logging to %s" % path)
+    except IOError, e:
+        print "Error writing to file handler. Ignoring."
+        print str(e)
+
+    if to_stdout:
+        try:
+            sth = logging.StreamHandler(sys.__stdout__)
+            sth.setLevel(logging.DEBUG)
+            log.addHandler(sth)
+            log.debug("Start logging to stdout.")
+        except IOError, e:
+            print "Error writing to stdout handler. Ignoring."
+            print str(e)
+
+    return log
+
+def release_log(log):
+    if not log:
+        return
+    log.debug("Releasing all handlers from log.")
+    while len(log.handlers):
+        handler = log.handlers[0]
+        if 'flush' in dir(handler):
+            handler.flush()
+        log.removeHandler(handler)
+        handler.close()
+

--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -37,7 +37,6 @@
 import utils
 import sys
 import os
-utils.configure_logging('auto-cert-kit')
 
 import testbase
 import inspect
@@ -397,22 +396,22 @@ def pre_flight_checks(session, config):
             raise Exception("Error: ethernet device %s on network %s is defined in the network config but does not have a matching partner. \
                 Please review the nework configuration and minumum requirements of this kit." % (k, v))
     
-@utils.log_exceptions
 def main(config, test_run_file):
     """Main routine - assess which tests should be run, and create
     output file"""
     
     session = get_xapi_session(config)
 
+    # Release current logger before running logrotate.
+    utils.release_logging()
+
     # Run log rotate before ACK produces any log.
-    for host in session.xenapi.host.get_all():
-        res = session.xenapi.host.call_plugin(host, 
+    for host_ref in session.xenapi.host.get_all():
+        res = session.xenapi.host.call_plugin(host_ref, 
                                     'autocertkit',
                                     'run_ack_logrotate', 
                                     {})
-    # logger can be broken due to os file handler.
-    utils.log = None
-    utils.log = utils.configure_logging('auto-cert-kit')
+    utils.configure_logging('auto-cert-kit')
 
     pre_flight_checks(session, config)
 

--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -30,7 +30,6 @@
 
 """A module for utility functions shared with multiple test cases"""
 import logging
-import logging.handlers
 import subprocess
 import datetime
 import XenAPI
@@ -47,6 +46,7 @@ import threading
 import re
 
 from acktools.net import route, generate_mac
+import acktools.log
 
 K = 1024
 M = 1024 * K
@@ -60,6 +60,7 @@ XE = '/opt/xensource/bin/xe'
 DROID_TEMPLATE_TAG = "droid_vm_template"
 REBOOT_ERROR_CODE = 3
 REBOOT_FLAG_FILE = "/opt/xensource/packages/files/auto-cert-kit/reboot"
+LOG_LOC = "/var/log/auto-cert-kit.log"
 
 # Capability Tags
 REQ_CAP = "REQ"
@@ -514,25 +515,14 @@ def configure_logging(name):
     """Method for configuring Logging"""
     global log
     if not log:
-        log = logging.getLogger(name)
-        log.setLevel(logging.DEBUG)
-
-        try:
-            fileh = logging.FileHandler('/var/log/auto-cert-kit.log')
-            fileh.setLevel(logging.DEBUG)
-            formatter = logging.Formatter('%%(asctime)-8s %s: %%(levelname)-8s %%(filename)s:%%(lineno)-10d %%(message)s' % name)
-            fileh.setFormatter(formatter)
-            log.addHandler(fileh)
-            log.debug("Added fileh")
-        except IOError, e:
-            print "Error writing to file handler. Ignoring."
-            print str(e)
-            
-        sth = logging.StreamHandler(sys.__stdout__)
-        sth.setLevel(logging.DEBUG)
-        log.debug("Adding sth")
-        log.addHandler(sth)
+        log = acktools.log.configure_log(name, LOG_LOC)
     return log
+
+def release_logging():
+    """Release logging object."""
+    global log
+    acktools.log.release_log(log)
+    log = None
 
 if not log:
     log = configure_logging('auto-cert-kit')

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -49,6 +49,7 @@ import tarfile
 import datetime
 
 from acktools.net import route
+import acktools.log
 
 # The biosdevname library has been moved in Tamapa,
 # so we must ensure that we check that we cope with
@@ -90,18 +91,17 @@ UNAME = "/bin/uname"
 
 ##### Logging setup
 
+LOG_LOC = '/var/log/auto-cert-kit-plugin.log'
+
 log = None
 def configure_logging(name):
     global log
-    log = logging.getLogger(name)
-    log.setLevel(logging.DEBUG)
-    sysh = logging.FileHandler('/var/log/auto-cert-kit-plugin.log')
-    sysh.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%%(asctime)-8s %s: %%(levelname)-8s %%(filename)s:%%(lineno)-10d %%(message)s' % name)
-    sysh.setFormatter(formatter)
-    log.addHandler(sysh)
-configure_logging('autocertkit')
+    if log:
+        acktools.log.release_log(log)
+    log = acktools.log.configure_log(name, LOG_LOC, False)
+    return log
 
+configure_logging('autocertkit')
 
 ##### Exceptions
 
@@ -372,9 +372,9 @@ def save_bugtool():
 def run_ack_logrotate(session, args):
     """Run logrotate for ACK logs"""
     ack_logrotate_dconf = '/etc/logrotate.d/autocertkit'
+    global log
     
     # This method should not log before logrotate execution to avoid os file handle error
-
     try:
         shutil.copyfile(LOGROTATE_CONF_LOC, ack_logrotate_dconf)
         call = ['/usr/sbin/logrotate', '-f', ack_logrotate_dconf]
@@ -383,7 +383,7 @@ def run_ack_logrotate(session, args):
         return str(e)
 
     # Restart logging and leave results of logrotate in the log.
-    configure_logging('autocertkit')
+    log = configure_logging('autocertkit')
     if res['returncode'] != 0:
         msg = "ERR: Failed to run logrotate."
         log.error("%s: %s" % (msg, res['stderr']))


### PR DESCRIPTION
When log is being refreshed to run logrotate, existing handlers were
not cleared properly.
