### PR TITLE
CA-148382: Make sure the auto-cert-kit script doesn't get deactivated on upgrade

### DIFF
--- a/xenserver-auto-cert-kit.spec.in
+++ b/xenserver-auto-cert-kit.spec.in
@@ -21,7 +21,11 @@ cd /opt/xensource/packages/files/auto-cert-kit/pypackages
 python setup.py install
 
 %preun
-chkconfig --del auto-cert-kit
+if [ $1 -eq 0 ] ; then
+    # Only execute on uninstall
+    chkconfig --del auto-cert-kit
+fi
+exit 0
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
Unfortunatly, due to the way RPM scriplets get executed, the chkconfig --del
auto-cert-kit command was being executed on upgrade after running the new
packages install scripts. This stopped re-running after reboot from working.

This patch should address that issue and make sure we only remove the chkconfig
entry when the RPM is actually being removed (in which case the next RPM to be
installed will setup the chkconfig entry correctly).

Signed-off-by: Rob Dobson rob.dobson@citrix.com
