### PR TITLE
Properly work around CA-146164.

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1531,7 +1531,8 @@ def run_xapi_async_tasks(session, funcs, timeout=300):
             task_refs.append((idx, ref))
 
         if should_timeout(start, timeout):
-            raise Exception("Async calls took too long to complete!" + 
+            # Change to this exception for work around CA-146164
+            raise TimeoutFunctionException("Async calls took too long to complete!" + 
                             "Perhaps, the operation has stalled? %d" % timeout)
         time.sleep(1)
 
@@ -1729,8 +1730,22 @@ def deploy_two_droid_vms(session, network_refs, sms=None):
         i = i + 1
 
     log.debug("Starting required VMs")
-    session.xenapi.VM.start_on(vm1_ref, host_master_ref, False, False)
-    session.xenapi.VM.start_on(vm2_ref, host_slave_ref, False, False)
+    try:
+        # Temporary setting time out to 3 mins to work around CA-146164.
+        run_xapi_async_tasks(session, \
+            [lambda: session.xenapi.Async.VM.start_on(vm1_ref,
+                                                     host_master_ref,
+                                                     False, False),
+            lambda: session.xenapi.Async.VM.start_on(vm2_ref,
+                                                     host_slave_ref,
+                                                     False, False)],
+            180)
+
+    except TimeoutFunctionException, e:
+        # Temporary ignore time out to start VM.
+        # If VM failed to start, test will fail while checking IPs.
+        log.debug(e.message)
+        log.debug("Async call timed out but VM may started properly. tests go on.")
 
     #Temp fix for establishing that a VM has fully booted before
     #continuing with executing commands against it.


### PR DESCRIPTION
This is properly work around CA-146164.
Changing asynchronous call into synchronous call was not enough as some configuration still fails randomly. Hence Instead of simple call change, putting some guarded code to avoid CA-146164 bug.
