### PR TITLE
test_name tag is generated when ACK is initiated.

### DIFF
--- a/autocertkit/test_generators.py
+++ b/autocertkit/test_generators.py
@@ -174,6 +174,10 @@ class TestGenerator(object):
                 
                 method_node.appendChild(result_node)
                 method_node.appendChild(info_node)
+                testname_node = doc.createElement('test_name')
+                testname_node.appendChild(doc.createTextNode('%s.%s' %
+                    (test_class_name.split('.')[1], str(method))))
+                method_node.appendChild(testname_node)
 
                 class_node.appendChild(method_node)
 


### PR DESCRIPTION
test_name tag was generated when test has finished. Now it is generated
when ACK is creating test_run.conf and updated when test method finishes.
