### PR TITLE
Wait link state is fully changed when changing nic state

### DIFF
--- a/autocertkit/network_tests.py
+++ b/autocertkit/network_tests.py
@@ -547,15 +547,15 @@ class BondingTestClass(testbase.NetworkTestClass):
         results.append(ping(vm1_ip, vm2_bondnic_ip, 'eth1'))
         
         #Test degraded bond
-        set_nic_device_status(self.piface, 'down')
+        set_nic_device_status(session, self.piface, 'down')
         results.append(ping(vm1_ip, vm2_bondnic_ip, 'eth1'))
         
         #Test degraded bond
-        set_nic_device_status(self.piface, 'up')
-        set_nic_device_status(self.siface, 'down')
+        set_nic_device_status(session, self.piface, 'up')
+        set_nic_device_status(session, self.siface, 'down')
         results.append(ping(vm1_ip, vm2_bondnic_ip, 'eth1'))
         
-        set_nic_device_status(self.siface, 'up')
+        set_nic_device_status(session, self.siface, 'up')
        
         rec = {}
         rec['data'] = results

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -83,6 +83,7 @@ IP = "/sbin/ip"
 ARPING = "/sbin/arping"
 DHCLIENT = "/sbin/dhclient"
 IFCONFIG = "/sbin/ifconfig"
+ETHTOOL = "/sbin/ethtool"
 KILL = "/bin/kill"
 SYSCTL = "/sbin/sysctl"
 CAT = "/bin/cat"
@@ -358,6 +359,33 @@ def get_vm_ips(session, vm_ref):
         if k.endswith('ip'):
             res["eth%s" % (k.replace('/ip',''))] = v
     return res
+
+@log_exceptions
+def get_local_device_linkstate(session, arg):
+    """ Return current operstate of network device."""
+
+    res = {}
+    device = validate_exists(arg, 'device', None, True)
+
+    output = make_local_call([IFCONFIG, device])['stdout']
+    if 'UP' in output:
+        res['operstate'] = 'up'
+    else:
+        res['operstate'] = 'down'
+    if 'RUNNING' in output:
+        res['carrier'] = 'running'
+    else:
+        res['carrier'] = ''
+
+    output = make_local_call([ETHTOOL, device])['stdout']
+    if 'Link detected: yes' in output:
+        res['link'] = 'yes'
+    elif 'Link detected: no' in output:
+        res['link'] = 'no'
+    else:
+        res['link'] = 'unknown'
+
+    return to_xml(res, 'linkstate')
     
 def save_bugtool():
     """Saves a bugtool and returns the name"""
@@ -1779,6 +1807,7 @@ if __name__ == '__main__':
                            'get_local_storage_devices': get_local_storage_devices,
                            'get_iface_stats': get_iface_stats,
                            'get_host_routes': get_host_routes,
+                           'get_local_device_linkstate': get_local_device_linkstate,
                            'create_output_package': create_output_package,
                            'start_iperf_server': start_iperf_server,
                            'add_route': add_route,


### PR DESCRIPTION
When ACK turns 'up' or 'down' a pif with 'ifconfig',
ACK now checks operstate, carrier state and physical link from ifconfig and
ethtool outputs.

This may help some environment and device driver that takes a few seconds to change link state.