### PR TITLE
Change deploy_two_vms to use synchronous call to start VMs.

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1784,22 +1784,26 @@ def deploy_two_droid_vms(session, network_refs, sms=None):
         i = i + 1
 
     log.debug("Starting required VMs")
-    try:
-        # Temporary setting time out to 3 mins to work around CA-146164.
-        run_xapi_async_tasks(session, \
-            [lambda: session.xenapi.Async.VM.start_on(vm1_ref,
-                                                     host_master_ref,
-                                                     False, False),
-            lambda: session.xenapi.Async.VM.start_on(vm2_ref,
-                                                     host_slave_ref,
-                                                     False, False)],
-            180)
+    # Temporary stop using Asynchronous call to start VMs
+    # to avoid XAPI issue, CA-160978 and CA-161590
+    session.xenapi.VM.start_on(vm1_ref, host_master_ref, False, False)
+    session.xenapi.VM.start_on(vm2_ref, host_slave_ref, False, False)
+    # try:
+    #     # Temporary setting time out to 3 mins to work around CA-146164.
+    #     run_xapi_async_tasks(session, \
+    #         [lambda: session.xenapi.Async.VM.start_on(vm1_ref,
+    #                                                  host_master_ref,
+    #                                                  False, False),
+    #         lambda: session.xenapi.Async.VM.start_on(vm2_ref,
+    #                                                  host_slave_ref,
+    #                                                  False, False)],
+    #         180)
 
-    except TimeoutFunctionException, e:
-        # Temporary ignore time out to start VM.
-        # If VM failed to start, test will fail while checking IPs.
-        log.debug("Timed out while starting VMs: %s" % e)
-        log.debug("Async call timed out but VM may started properly. tests go on.")
+    # except TimeoutFunctionException, e:
+    #     # Temporary ignore time out to start VM.
+    #     # If VM failed to start, test will fail while checking IPs.
+    #     log.debug("Timed out while starting VMs: %s" % e)
+    #     log.debug("Async call timed out but VM may started properly. tests go on.")
 
     #Temp fix for establishing that a VM has fully booted before
     #continuing with executing commands against it.


### PR DESCRIPTION
When 2 VMs are created and starts on each host, async call may not return results. (CA-146164) Even if we ignore response of async calls, XAPI may fail to track VMs' power and poeration status. (CA-160978) We can try to force shutdown VMs, but it sometimes halts during the operation. (CA-161590) To avoid these XAPI issues, deploy_two_vms will starts VMs synchronously until issues are fixed.

As this function is not being used in operation tests (which means all tests that use this function are not testing XS functionality such as async call or plugin call), it won't affect result of tests or certification.