### PR TITLE
Fix for late ip binding in 2nd VIF issue.

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1084,6 +1084,25 @@ def wait_for_ip(session, vm_ref, device, timeout=300):
     raise Exception("""Timeout has been exceeded waiting for IP
                      address of VM to be returned %s """ % str(timeout))
 
+def wait_for_all_ips(session, vm_ref, timeout=300):
+    """wait for all interface to have IPs"""
+
+    ips = {}
+    if session.xenapi.VM.get_is_control_domain(vm_ref):
+        host_ref = session.xenapi.VM.resident_on(vm_ref)
+        for pif in session.xenapi.PIF.get_all():
+            if host_ref == session.xenapi.PIF.get_host(pif):
+                device = 'eth' + str(session.xenapi.PIF.get_device(pif)).strip()
+                ips[device] = _get_control_domain_ip(session, vm_ref, device)
+
+    else:
+        for vif in session.xenapi.VIF.get_all():
+            if vm_ref == session.xenapi.VIF.get_VM(vif):
+                device = 'eth' + str(session.xenapi.VIF.get_device(vif)).strip()
+                ips[device] = wait_for_ip(session, vm_ref, device, timeout)
+
+    return ips
+
 def _is_link_up(statedict):
     """Evaluate current operstate, carrier and link from dict."""
 
@@ -1638,7 +1657,7 @@ def deploy_count_droid_vms_on_host(session, host_ref, network_refs, vm_count, sm
     # Wait for IPs to be returned
     log.debug("Wait for IPs...")
     for vm_ref in vm_ref_list:
-        wait_for_ip(session, vm_ref, 'eth0')
+        wait_for_all_ips(session, vm_ref)
     log.debug("IP's retrieved...")
 
     # Check the VMs are in the 'Running' state.
@@ -1713,7 +1732,7 @@ def deploy_slave_droid_vm(session, network_refs, sms=None):
 
     #Temp fix for establishing that a VM has fully booted before
     #continuing with executing commands against it.
-    wait_for_ip(session, vm_ref, 'eth0')
+    wait_for_all_ips(session, vm_ref)
 
     return vm_ref
 
@@ -1804,10 +1823,9 @@ def deploy_two_droid_vms(session, network_refs, sms=None):
     #Temp fix for establishing that a VM has fully booted before
     #continuing with executing commands against it.
     log.debug("Wait for IPs...")
-    wait_for_ip(session, vm1_ref, 'eth0')
-    wait_for_ip(session, vm2_ref, 'eth0')
+    wait_for_all_ips(session, vm1_ref)
+    wait_for_all_ips(session, vm2_ref)
     log.debug("IP's retrieved...")
-
 
     # Make plugin calls
     for vm_ref in [vm1_ref, vm2_ref]:


### PR DESCRIPTION
When Droid VM has multiple NICS with static IP manager, in some environment,
eth1 of VM may have IP a bit later than eth0. This sometimes causes iperf packet
sending failure.