### PR TITLE
fix travis-ci badge to point to the xenserver owned repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 auto-cert-kit
 =============
-[![Build Status](https://travis-ci.org/rdobson/auto-cert-kit.png?branch=master)](https://travis-ci.org/rdobson/auto-cert-kit) [![Coverage Status](https://coveralls.io/repos/xenserver/auto-cert-kit/badge.png?branch=master)](https://coveralls.io/r/xenserver/auto-cert-kit?branch=master)
+[![Build Status](https://travis-ci.org/xenserver/auto-cert-kit.png?branch=master)](https://travis-ci.org/xenserver/auto-cert-kit) [![Coverage Status](https://coveralls.io/repos/xenserver/auto-cert-kit/badge.png?branch=master)](https://coveralls.io/r/xenserver/auto-cert-kit?branch=master)
 
 Automated Certification Kit for validating hardware against XenServer


### PR DESCRIPTION
as per title, travis-ci badge was still pointing at rdobson account