### PR TITLE
Fix issue with crashdump test (fixes issue #105)

### DIFF
--- a/autocertkit/operations_tests.py
+++ b/autocertkit/operations_tests.py
@@ -233,42 +233,37 @@ class CrashDumpTestClass(testbase.OperationsTestClass):
         """Check crashdump is created properly."""
         log.debug("Running Crashdump test.")
         if not get_reboot_flag():
-            numberofcds = len(retrieve_crashdumps(session))
             tc_info = {}
             tc_info['device'] = self.config['device_config']['udid']
             tc_info['test_class'] = self.__class__.__module__ + '.' + self.__class__.__name__
             tc_info['test_method'] = 'test_crashdump'
-            tc_info['cds'] = numberofcds
+            tc_info['existing_crashdumps'] = [cd['timestamp'].strftime("%Y-%m-%d %H:%M:%S") for cd in retrieve_crashdumps(session)]
+            tc_info['crash_begin_time'] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             set_reboot_flag(tc_info)
-            crashtime = get_reboot_flag_timestamp()
-            log.debug("The reboot flag's timestamp is set to: '%s'" % str(crashtime))
+            log.debug("The reboot flag's timestamp is set to: '%s'" % str(get_reboot_flag_timestamp()))
             time.sleep(5) # host crash need to be done after flag is created to compare.
             host_crash(self.session)
-
-        # Check number of crashdumps are increased by 1.
+        # Check tc_info is persistent.
         tc_info = get_reboot_flag()
-        numberofcds = len(retrieve_crashdumps(session))
-        if not 'cds' in tc_info:
-            raise Exception("Reboot flag does not include crashdump info. Does host restarted by forced crashdump?")
-
-        if not numberofcds == tc_info['cds'] + 1:
-            raise Exception("Host does not created crashdump properly: expected %d, found %d" %
-                    (tc_info['cds'] + 1, numberofcds))
-        
+        log.debug("tc_info from reboot flag: %s" % str(tc_info))
+        if 'existing_crashdumps' not in tc_info or 'crash_begin_time' not in tc_info:
+            raise Exception("Reboot flag is not persistent and does not include crashdump info. Does host restarted by forced crashdump?")
+        crash_beg_time = datetime(*(time.strptime(tc_info['crash_begin_time'],"%Y-%m-%d %H:%M:%S")[0:6]))
+        crash_end_time = datetime.now()
+        existing_cd_timestamps = [ datetime(*(time.strptime(ts,"%Y-%m-%d %H:%M:%S")[0:6])) for ts in tc_info['existing_crashdumps']]
+        crashdumps_all = retrieve_crashdumps(session)
+        log.debug("crashdumps's timestamp before crash: %s , crashdumps after crash %s" % (str(tc_info['existing_crashdumps']), str(crashdumps_all)))
+        crashdumps_matching = [cd for cd in crashdumps_all if cd['timestamp'] not in existing_cd_timestamps]
+        # Check we have a new crashdump.
+        if not len(crashdumps_matching)==1:
+            raise Exception("Host didn't create crashdump properly. number of new crashdumps: %d" % len(crashdumps_matching))
         res = {'info': "An additional crashdump was detected."}
-
-        # Check the last crashdump is created after crashing the host.
-        crashdump = retrieve_latest_crashdump(session)
-        log.debug("Latest crashdump: %s" % crashdump)
-
-        crashtime = get_reboot_flag_timestamp()
-        cdtimestamp = crashdump['timestamp']
-
-        log.debug("Crash time: %s / Crashdump timestamp: %s" % (str(crashtime), str(cdtimestamp)))
-
-        if crashtime > cdtimestamp:
-            log.warning("Latest crashdump is created before host crashed by testcase. hwclock may be out of sync.")
-            res['warning'] = "Latest crashdump is created before host crashed by testcase. hwclock may be out of sync."
+        log.debug("matched crashdump timestamp: %s, crash duration: %s to %s" % (str(crashdumps_matching[0]['timestamp']), str(crash_beg_time), str(crash_end_time)))
+        crashdumps_matching = [cd for cd in crashdumps_matching if crash_beg_time < cd['timestamp'] and cd['timestamp'] < crash_end_time]
+        # [WARNING ONLY] Check new crashdump was created during host crash.
+        if not len(crashdumps_matching)==1:
+            log.warning("New crashdump doesn't match the time of host crash. hwclock may be out of sync.")
+            res['warning'] = "New crashdump doesn't match the time of host crash. hwclock may be out of sync."
 
         return res
 


### PR DESCRIPTION
Fixed issue with crashdump test, now test checks for a new crashdump by comparing timestamps instead of relying on count. This fixes "XS only keeps upto 4 latest crashdumps #105"

log from tested job on clearwater pool with master host having 4 crashdumps initially:
```
2015-11-23 08:32:00,815 auto-cert-kit: DEBUG    testbase.py:95         Test Selected = test_crashdump
2015-11-23 08:32:00,815 auto-cert-kit: DEBUG    testbase.py:110        ******** CrashDumpTestClass.test_crashdump ********
2015-11-23 08:32:00,815 auto-cert-kit: DEBUG    operations_tests.py:234        Running Crashdump test.
2015-11-23 08:32:00,816 auto-cert-kit: DEBUG    operations_tests.py:250        tc_info from reboot flag: {'device': u'5', 'crash_begin_time': '2015-11-23 08:25:43', 'test_class': 'operations_tests.CrashDumpTestClass', 'test_method': 'test_crashdump', 'existing_crashdumps': ['2015-11-23 06:20:12', '2015-11-23 06:30:01', '2015-11-23 06:25:09', '2015-11-23 07:05:51']}
2015-11-23 08:32:00,995 auto-cert-kit: DEBUG    utils.py:1906       [{'timestamp': '20151123-063001-UTC', 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': '292918'}, {'timestamp': '20151123-062509-UTC', 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': '281856'}, {'timestamp': '20151123-070551-UTC', 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': '331701'}, {'timestamp': '20151123-082639-UTC', 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': '344185'}]
2015-11-23 08:32:00,995 auto-cert-kit: DEBUG    utils.py:685        Retained Crashdumps: [{'timestamp': datetime.datetime(2015, 11, 23, 6, 30, 1), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 292918}, {'timestamp': datetime.datetime(2015, 11, 23, 6, 25, 9), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 281856}, {'timestamp': datetime.datetime(2015, 11, 23, 7, 5, 51), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 331701}, {'timestamp': datetime.datetime(2015, 11, 23, 8, 26, 39), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 344185}]
2015-11-23 08:32:00,996 auto-cert-kit: DEBUG    operations_tests.py:258        crashdumps's timestamp before crash: ['2015-11-23 06:20:12', '2015-11-23 06:30:01', '2015-11-23 06:25:09', '2015-11-23 07:05:51'] , crashdumps after crash [{'timestamp': datetime.datetime(2015, 11, 23, 6, 30, 1), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 292918}, {'timestamp': datetime.datetime(2015, 11, 23, 6, 25, 9), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 281856}, {'timestamp': datetime.datetime(2015, 11, 23, 7, 5, 51), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 331701}, {'timestamp': datetime.datetime(2015, 11, 23, 8, 26, 39), 'host': 'OpaqueRef:52f71416-b1e1-4d85-c2e5-516a4fee5908', 'size': 344185}]
2015-11-23 08:32:00,996 auto-cert-kit: DEBUG    operations_tests.py:266        matched crashdump timestamp: 2015-11-23 08:26:39, crash duration: 2015-11-23 08:25:43 to 2015-11-23 08:32:00.827609
2015-11-23 08:32:00,996 auto-cert-kit: DEBUG    testbase.py:151        Test case pass: CrashDumpTestClass.test_crashdump

```

and similar on trunk:

```
2015-11-23 11:29:24,730 auto-cert-kit: DEBUG    testbase.py:95         Test Selected = test_crashdump
2015-11-23 11:29:24,730 auto-cert-kit: DEBUG    testbase.py:110        ******** CrashDumpTestClass.test_crashdump ********
2015-11-23 11:29:24,730 auto-cert-kit: DEBUG    operations_tests.py:234        Running Crashdump test.
2015-11-23 11:29:24,731 auto-cert-kit: DEBUG    operations_tests.py:248        tc_info from reboot flag: {'device': u'6', 'crash_begin_time': '2015-11-23 11:22:22', 'test_class': 'operations_tests.CrashDumpTestClass', 'test_method': 'test_crashdump', 'existing_crashdumps': ['2015-11-23 10:28:26', '2015-11-23 10:33:03', '2015-11-23 10:23:50', '2015-11-23 10:19:18']}
2015-11-23 11:29:24,953 auto-cert-kit: DEBUG    utils.py:1906       [{'timestamp': '20151123-102826-UTC', 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': '1075763'}, {'timestamp': '20151123-103303-UTC', 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': '1077190'}, {'timestamp': '20151123-102350-UTC', 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': '1075798'}, {'timestamp': '20151123-112430-UTC', 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': '1139619'}]
2015-11-23 11:29:24,953 auto-cert-kit: DEBUG    utils.py:685        Retained Crashdumps: [{'timestamp': datetime.datetime(2015, 11, 23, 10, 28, 26), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1075763}, {'timestamp': datetime.datetime(2015, 11, 23, 10, 33, 3), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1077190}, {'timestamp': datetime.datetime(2015, 11, 23, 10, 23, 50), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1075798}, {'timestamp': datetime.datetime(2015, 11, 23, 11, 24, 30), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1139619}]
2015-11-23 11:29:24,953 auto-cert-kit: DEBUG    operations_tests.py:255        crashdumps's timestamp before crash: ['2015-11-23 10:28:26', '2015-11-23 10:33:03', '2015-11-23 10:23:50', '2015-11-23 10:19:18'] , crashdumps after crash [{'timestamp': datetime.datetime(2015, 11, 23, 10, 28, 26), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1075763}, {'timestamp': datetime.datetime(2015, 11, 23, 10, 33, 3), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1077190}, {'timestamp': datetime.datetime(2015, 11, 23, 10, 23, 50), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1075798}, {'timestamp': datetime.datetime(2015, 11, 23, 11, 24, 30), 'host': 'OpaqueRef:8ca6de2b-1d80-4b5f-126c-daa9bb7a1c0b', 'size': 1139619}]
2015-11-23 11:29:24,954 auto-cert-kit: DEBUG    operations_tests.py:261        matched crashdump timestamp: 2015-11-23 11:24:30, crash duration: 2015-11-23 11:22:22 to 2015-11-23 11:29:24.752956
2015-11-23 11:29:24,954 auto-cert-kit: DEBUG    testbase.py:151        Test case pass: CrashDumpTestClass.test_crashdump

```