### PR TITLE
Changed installer requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ $(TEST_KIT_RPM): $(TEST_KIT_SPEC) $(RPM_DIRECTORIES)
 	$(RPMBUILD) -bb $(TEST_KIT_SPEC)
 
 $(SUPP_PACK_ISO): $(TEST_KIT_RPM) $(DOM0_RPMS)
-	python setup-supp-pack.py --out $(dir $@) --pdn $(PRODUCT_BRAND) --pdv $(PRODUCT_VERSION) --bld $(BUILD) $^
+	python setup-supp-pack.py --out $(dir $@) --pdn $(PRODUCT_BRAND) --pdv $(PRODUCT_VERSION) --pln $(PLATFORM_NAME) --plv $(PLATFORM_VERSION) --bld $(BUILD) $^
 
 pylint:
 	$(PYLINT) $(TEST_KIT)/*.py

--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -416,6 +416,7 @@ def main(config, test_run_file):
     pre_flight_checks(session, config)
 
     config['xs_version'] = utils.get_xenserver_version(session)
+    config['xcp_version'] = utils.get_xcp_version(session)
 
     generate_test_config(session, config, test_run_file)
     # Logout of XAPI session anyway - the test runner will create a new session

--- a/autocertkit/testbase.py
+++ b/autocertkit/testbase.py
@@ -51,7 +51,8 @@ class TestClass(object):
     required_config = []
     session = None
     base_tag = "Base"
-    XS = ["> 5.6"]
+    XS_REQ = ">= 6.0"
+    XCP_REQ = ">= 1.0"
     REQUIRED_FOR = None
 
     def __init__(self, session, config):
@@ -167,10 +168,13 @@ class TestClass(object):
                 log.debug("Tag %s: %s" % (tag, self.config[tag]))
 
         xs_version = get_xenserver_version(self.session)
-        for expr in self.XS:
-            if not eval_expr(expr, xs_version):
-                raise Exception("Could not run test due to XenServer version constraints:" +
-                                " %s" % self.XS)
+        if eval_expr(self.XS_REQ, xs_version):
+            return
+        xcp_version = get_xcp_version(self.session)
+        if eval_expr(self.XCP_REQ, xcp_version):
+            return
+
+        raise Exception("versions do not meet requirements.")
 
     def list_tests(self):
         """Return a list of tests contained within this class"""

--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -733,6 +733,19 @@ def get_xenserver_version(session):
             return version
     raise Exception("XenServer Version could not be detected! %s" % xs_str)
 
+def get_xcp_version(session):
+    """Return the XCP version (using the master host)"""
+    master_ref = get_pool_master(session)
+    software = session.xenapi.host.get_software_version(master_ref)
+    xs_str = software['xcp:main']
+    #parse string of the form: 'XenServer Pack, version 6.0.0, build 50762c'
+    arr = xs_str.split(',')
+    for item in arr:
+        if item.strip().startswith('version'):
+            version = item.strip().split(' ')[1]
+            return version
+    raise Exception("XCP Version could not be detected! %s" % xs_str)
+
 def get_kernel_version(session):
     """Return kernel version using uname"""
     host = get_pool_master(session)    

--- a/setup-supp-pack.py
+++ b/setup-supp-pack.py
@@ -4,15 +4,17 @@ from optparse import OptionParser
 parser = OptionParser()
 parser.add_option('--pdn', dest="product_name")
 parser.add_option('--pdv', dest="product_version")
+parser.add_option('--pln', dest="platform_name")
+parser.add_option('--plv', dest="platform_version")
 parser.add_option('--bld', dest="build")
 parser.add_option('--out', dest="outdir")
 (options, args) = parser.parse_args()
 
-xs = Requires(originator='xs', name='main', test='ge', 
-               product=options.product_name, version='5.6.100', 
-               build='39265p')
+xs = Requires(originator='xcp', name='main', test='ge',
+               product=options.platform_name, version='1.0.99',
+               build='50762p')
 
-setup(originator='xs', name='xs-auto-cert-kit', product=options.product_name, 
-      version=options.product_version, build=options.build, vendor='Citrix Systems, Inc.', 
+setup(originator='xs', name='xs-auto-cert-kit', product=options.platform_name, 
+      version=options.platform_version, build=options.build, vendor='Citrix Systems, Inc.', 
       description="XenServer Auto Cert Kit", packages=args, requires=[xs],
       outdir=options.outdir, output=['iso'])


### PR DESCRIPTION
1. Now ACK supports from XenServer 6.0 and onwards
2. Now ACK requires platform (XCP) instead of product (XS)