### PR TITLE
Force close socket when use paramiko

### DIFF
--- a/autocertkit/ssh.py
+++ b/autocertkit/ssh.py
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
 # SUCH DAMAGE.
 
-import socket, string, sys, os, os.path, traceback, time
+import socket, string, sys, os, os.path, traceback, time, gc
 import paramiko
 
 SSHPORT = 22
@@ -148,8 +148,11 @@ class SSHSession:
 
     def close(self):
         if self.trans:
+            self.trans.sock.shutdown(socket.SHUT_RDWR)
             self.trans.close()
             self.trans = None
+            gc.collect()
+            time.sleep(5)
 
     def __del__(self):
         self.close()
@@ -220,16 +223,24 @@ class SFTPSession(SSHSession):
                           nowarn=self.nowarn)
 
     def close(self):
+        gc = False
         if self.client:
             try:
+                self.client._tansport.sock.shutdown(socket.SHUT_RDWR)
                 self.client.close()
+                gc = True
             except Exception, e:
                 log.debug("SFTP close exception %s" % (str(e)))
         if self.trans:
             try:
+                self.trans.sock.shutdown(socket.SHUT_RDWR)
                 self.trans.close()
+                gc = True
             except Exception, e:
                 log.debug("SFTP trans close exception %s" % (str(e)))
+        if gc:
+            gc.collect()
+            time.sleep(5)
 
     def copyTo(self, source, dest, preserve=True):
         log.debug("SFTP local:%s to remote:%s" % (source, dest))

--- a/autocertkit/ssh.py
+++ b/autocertkit/ssh.py
@@ -138,7 +138,7 @@ class SSHSession:
         else:
             if not k:
                 raise RuntimeError("No password given and no key read")
-            self.log("Using SSH public key %s" % (dsskey))
+            self.log.debug("Using SSH public key %s" % (dsskey))
             self.trans.auth_publickey(username, k)
         if not self.trans.is_authenticated():
             raise RuntimeError("Problem with SSH authentication")
@@ -167,10 +167,9 @@ class SFTPSession(SSHSession):
                  password=None,
                  nowarn=False):
         self.log = log
-        self.log("SFTP session to %s@%s" % (username, ip))
+        self.log.debug("SFTP session to %s@%s" % (username, ip))
         self.ip = ip
         self.username = username
-        self.log = log
         self.timeout = timeout
         self.password = password
         self.nowarn = nowarn


### PR DESCRIPTION
ACK uses paramiko for SSH management.
When paramiko closes SSH connection, it explicitely calls close() method of socket, of which resource is collected when GC is called. This may prolong network connectivity in switch between 2 hops, which mat be different from route path that ACK tries to test.

By explcitly calling shutdown from socket object of SSHSession and force GC, we can override this 'alive' route path. As this route path is maintain in switch, ACK is doing its best efforts to reset route path.
