### PR TITLE
Re-run iperf tests on failure once and log existing failure as warning.

### DIFF
--- a/autocertkit/testbase.py
+++ b/autocertkit/testbase.py
@@ -127,6 +127,7 @@ class TestClass(object):
                 copy_field(rec, res, 'data')
                 copy_field(rec, res, 'config')
                 copy_field(rec, res, 'reason', False)
+                copy_field(rec, res, 'warning', False)
 
             except Exception, e:
                 traceb = traceback.format_exc()


### PR DESCRIPTION
Iperf tests can fail occasionally due to intermittent iperf/network issue(s),
These are not ACK failure and rerun will avoid seeing noise.