### PR TITLE
Make CrashDump test is optional (opt-in default)

### DIFF
--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -94,7 +94,7 @@ def parse_cmd_args():
                       dest="exclude",
                       action="append",
                       default=[],
-                      help="Exclude one or multiple set of tests. (OVS | BRIDGE | LSTOR | CPU | OPS).")
+                      help="Exclude one or multiple set of tests. (OVS | BRIDGE | LSTOR | CPU | OPS | CRASH).")
     parser.add_option("-n","--netconf",
                       dest="netconf",
                       help="Specify the network config file.")

--- a/autocertkit/test_generators.py
+++ b/autocertkit/test_generators.py
@@ -274,6 +274,9 @@ class OperationsTestGenerator(TestGenerator):
     def filter_test_classes(self, test_classes):
         if 'OPS' in self.config['exclude']:
             return []
+        if 'CRASH' in self.config['exclude']:
+            test_classes = [(testname, testclass) for testname, testclass
+                    in test_classes if 'CrashDump' not in testname]
         return test_classes
 
     def get_device_config(self):


### PR DESCRIPTION
-e option now have CRASH to exclude CrashDump test form OperationTestClass