### PR TITLE
Fixed SIG issue

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1910,8 +1910,8 @@ class TimeoutFunction:
         try:
             result = self.function(*args)
         finally:
+            signal.alarm(0)
             signal.signal(signal.SIGALRM, old)
-        signal.alarm(0)
         return result
 
 def xml_to_dicts(xml, tag):


### PR DESCRIPTION
When function, which passed into TimeoutFunction class, raises unhandled
exception before timeout, ALARM may not cleared properly as it is outside
of try block. Moved alarm clear routine into finally block.