### PR TITLE
updating pylint code to work with latest ACK

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -63,7 +63,7 @@ disable=W0603,R0913,W0703,W0614,R0201,W0401,W0404
 
 # set the output format. Available formats are text, parseable, colorized and
 # html
-output-format=parseable
+output-format=text
 
 # Include message's id in output
 include-ids=yes

--- a/pylint.sh
+++ b/pylint.sh
@@ -1,24 +1,16 @@
 #!/bin/sh
+if [ $# -eq 0 ]
+then
+echo "ACK Code Violations:"
+files=`find -not -path "./XenAPI/*" |
+    egrep -e '\.(py)$$' -e 'plugins/autocertkit' |
+    sort | uniq`
+else
+files="$1"
+fi 
 
-set -eu
-
-files="$@"
-thisdir=$(dirname "$0")
-
-output=""
-
-for file in "network_tests" "cpu_tests" "operations_tests" "storage_tests" "utils" "network_tests" "testbase" 
+for file in $files
 do
     echo "Running pylint on $file..."
-    cd "kit"
-    #An addition to use the same script in/out of the chroot
-    pylint --rcfile=../pylint.rc --persistent=n "$file.py"
-    #CMD used for the purposes of being inside the chroot
-    out=$(pylint --rcfile=../pylint.rc --persistent=n "$file.py")
-    cd "../"
-    if [ "$out" ]
-	then
-	    echo $out 1>&2
-	exit 1
-	fi
+    pylint --rcfile=pylint.rc $file
 done


### PR DESCRIPTION
Existing code was obsolete and was not applicable. I have updated two files to run for latest ACK and will check all py files + ACK plugin, excluding XenAPI files.