### PR TITLE
removing --use-mirrors as pip 7 and later no longer support it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - "2.7"
 
 install:
-    - "pip install -r requirements.txt --use-mirrors"
+    - "pip install -r requirements.txt"
 
 script: 
     - nosetests -c .noserc autocertkit/tests/ acktools/


### PR DESCRIPTION
Travis running for Xenserver/auto-cert-kit is often calling pip 8.1.2 and pip 7 and later do not support --use-mirrors option.

This is leading to travis check failure. Failure snippet is as below:

```
$ pip --version
pip 8.1.2 from /home/travis/virtualenv/python2.7.12/lib/python2.7/site-packages (python 2.7)
$ pip install -r requirements.txt --use-mirrors
Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...
no such option: --use-mirrors
```
