### PR TITLE
autopep8: Adding automated tool to format extra/missing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 
 script: 
     - nosetests -c .noserc autocertkit/tests/ acktools/
+    - tools/checkpep8.sh
 
 after_success:
     - coveralls

--- a/acktools/__init__.py
+++ b/acktools/__init__.py
@@ -2,6 +2,7 @@
 
 import subprocess
 
+
 def make_local_call(call):
     """Function wrapper for making a simple call to shell"""
     process = subprocess.Popen(call, stdout=subprocess.PIPE)
@@ -10,4 +11,3 @@ def make_local_call(call):
         return str(stdout).strip()
     else:
         raise Exception("Error: '%s' '%s'" % (stdout, stderr))
-

--- a/acktools/log.py
+++ b/acktools/log.py
@@ -3,37 +3,38 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 
 import sys
 import logging
 import logging.handlers
+
 
 def configure_log(name, path, to_stdout=True):
     log = logging.getLogger(name)
@@ -42,7 +43,8 @@ def configure_log(name, path, to_stdout=True):
     try:
         fileh = logging.FileHandler(path)
         fileh.setLevel(logging.DEBUG)
-        formatter = logging.Formatter('%%(asctime)-8s %s: %%(levelname)-8s %%(filename)s:%%(lineno)-10d %%(message)s' % name)
+        formatter = logging.Formatter(
+            '%%(asctime)-8s %s: %%(levelname)-8s %%(filename)s:%%(lineno)-10d %%(message)s' % name)
         fileh.setFormatter(formatter)
         log.addHandler(fileh)
     except IOError, e:
@@ -60,6 +62,7 @@ def configure_log(name, path, to_stdout=True):
 
     return log
 
+
 def release_log(log):
     if not log:
         return
@@ -70,4 +73,3 @@ def release_log(log):
             handler.flush()
         log.removeHandler(handler)
         handler.close()
-

--- a/acktools/net/__init__.py
+++ b/acktools/net/__init__.py
@@ -1,13 +1,14 @@
 import random
 
+
 def generate_mac():
     """
     This function will generate a random MAC.
     The function generates a MAC with the Xensource, Inc. OUI '00:16:3E'.
     Care should be taken to ensure duplicates are not used.   
     """
-    mac = [ 0x00, 0x16, 0x3e, 
-            random.randint(0x00, 0x7f),
-            random.randint(0x00, 0xff),
-            random.randint(0x00, 0xff) ]
+    mac = [0x00, 0x16, 0x3e,
+           random.randint(0x00, 0x7f),
+           random.randint(0x00, 0xff),
+           random.randint(0x00, 0xff)]
     return ':'.join(map(lambda x: "%02x" % x, mac))

--- a/acktools/net/route.py
+++ b/acktools/net/route.py
@@ -3,37 +3,38 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 import acktools
 from acktools import utils
 
 ROUTE_CLI = "/sbin/route"
+
 
 class Route(object):
     """Class for representing a route object"""
@@ -64,6 +65,7 @@ class Route(object):
             rec[key] = getattr(self, key)
         return rec
 
+
 class RouteTable(object):
     """Class for representing a route table which constitutes 
     a collection of route objects."""
@@ -72,7 +74,7 @@ class RouteTable(object):
         self.routes = route_obj_list
 
     def get_routes(self, dest=None, mask=None, gw=None, iface=None):
-        
+
         matching_routes = []
 
         for route in self.routes:
@@ -88,7 +90,7 @@ class RouteTable(object):
                 # Route clearly matches the required fields
                 matching_routes.append(route)
 
-        return matching_routes    
+        return matching_routes
 
     def get_missing(self, rt):
         """Compare this route table with another passed in"""
@@ -101,8 +103,10 @@ class RouteTable(object):
                 missing.append(route)
         return missing
 
+
 def get_route_table():
-    return acktools.make_local_call([ROUTE_CLI,'-n'])    
+    return acktools.make_local_call([ROUTE_CLI, '-n'])
+
 
 def get_all_routes():
     """Return a list of route objects for all the routing
@@ -110,12 +114,12 @@ def get_all_routes():
 
     output = get_route_table()
     lines = output.split('\n')
-    
+
     if lines[0] != "Kernel IP routing table":
         raise Exception("Error! Unexpected format: '%s'" % output)
 
     # Join the table lines
-    route_table = "\n".join(lines[1:])    
+    route_table = "\n".join(lines[1:])
 
     # Parse the table to produce a list of recs
     recs = utils.cli_table_to_recs(route_table)
@@ -128,7 +132,7 @@ def get_all_routes():
                       rec['Gateway'],
                       rec['Genmask'],
                       rec['Iface'],
-                     )
+                      )
 
         route_list.append(route)
 

--- a/acktools/net/tests/net_tests.py
+++ b/acktools/net/tests/net_tests.py
@@ -3,6 +3,7 @@ import re
 
 from acktools.net import generate_mac
 
+
 class MACGeneratorTest(unittest.TestCase):
     """Test util methods for manipulating MACs"""
 

--- a/acktools/net/tests/route_tests.py
+++ b/acktools/net/tests/route_tests.py
@@ -11,17 +11,17 @@ import acktools
 class RouteObjectTests(unittest.TestCase):
 
     route_rec = {
-                 'dest': '0.0.0.0',
-                 'gw': '10.80.2.1',
-                 'mask': '0.0.0.0',
-                 'iface': 'eth1',
-                }
-        
+        'dest': '0.0.0.0',
+        'gw': '10.80.2.1',
+        'mask': '0.0.0.0',
+        'iface': 'eth1',
+    }
+
     def setUp(self):
         self.route_obj = route.Route(**self.route_rec)
 
     def test_get_dest(self):
-        self.assertEqual(self.route_obj.get_dest(), 
+        self.assertEqual(self.route_obj.get_dest(),
                          self.route_rec['dest'])
 
     def test_get_gw(self):
@@ -48,12 +48,12 @@ class RouteObjectTests(unittest.TestCase):
 
 class RouteTableTests(unittest.TestCase):
 
-    route_recs = [ 
-                   {'dest': '0.0.0.0', 'gw': '10.80.2.1', 
-                    'mask': '0.0.0.0', 'iface': 'eth1'},
-                   {'dest': '192.168.0.0', 'gw':'192.168.0.1',
-                    'mask': '255.255.255.0', 'iface':'eth3'}
-                 ]
+    route_recs = [
+        {'dest': '0.0.0.0', 'gw': '10.80.2.1',
+         'mask': '0.0.0.0', 'iface': 'eth1'},
+        {'dest': '192.168.0.0', 'gw': '192.168.0.1',
+         'mask': '255.255.255.0', 'iface': 'eth3'}
+    ]
 
     def setUp(self):
         route_list = []
@@ -91,9 +91,9 @@ class RouteTableTests(unittest.TestCase):
             self.assertEqual(route.get_gw(), rec['gw'])
 
     def test_get_nonexistent_route(self):
-        routes = self.route_table.get_routes('192.145.2.5','255.255.255.0')
+        routes = self.route_table.get_routes('192.145.2.5', '255.255.255.0')
         self.assertEqual(routes, [])
-        routes = self.route_table.get_routes('192.168.0.0','255.255.254.0')
+        routes = self.route_table.get_routes('192.168.0.0', '255.255.254.0')
         self.assertEqual(routes, [])
 
     def test_get_missing_routes(self):
@@ -108,11 +108,12 @@ class RouteTableTests(unittest.TestCase):
 
 
 ROUTE_TABLE = \
-"""Kernel IP routing table
+    """Kernel IP routing table
 Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 0.0.0.0         10.80.2.1       0.0.0.0         UG    0      0        0 eth0
 10.80.2.0       0.0.0.0         255.255.254.0   U     1      0        0 eth0
 169.254.0.0     0.0.0.0         255.255.0.0     U     1000   0        0 eth0"""
+
 
 class RouteMethodTests(unittest.TestCase):
 
@@ -126,7 +127,7 @@ class RouteMethodTests(unittest.TestCase):
             self.assertEqual(route_obj.get_gw(), gw)
             self.assertEqual(route_obj.get_mask(), mask)
             self.assertEqual(route_obj.get_iface(), iface)
-        
+
         for route_obj in routes:
             if route_obj.get_dest() == '0.0.0.0':
                 assert_about_obj(route_obj, '10.80.2.1', '0.0.0.0', 'eth0')
@@ -135,7 +136,7 @@ class RouteMethodTests(unittest.TestCase):
             elif route_obj.get_dest() == '169.254.0.0':
                 assert_about_obj(route_obj, '0.0.0.0', '255.255.0.0', 'eth0')
             else:
-                raise Exception("Error: route not in original list! " \
+                raise Exception("Error: route not in original list! "
                                 "'%s'" % route)
 
     @mock.patch('acktools.net.route.get_route_table', mock.Mock(return_value='Blah'))
@@ -145,4 +146,3 @@ class RouteMethodTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/acktools/tests/acktools_tests.py
+++ b/acktools/tests/acktools_tests.py
@@ -5,8 +5,9 @@ import acktools
 import subprocess
 from mock import Mock
 
+
 class MockProcess:
-    
+
     returncode = 0
     stderr = None
 
@@ -16,7 +17,7 @@ class MockProcess:
             self.returncode = 1
             self.stderr = err
 
-    def stderr(self): 
+    def stderr(self):
         return self.stderr
 
     def stdout(self):
@@ -29,17 +30,16 @@ class MockProcess:
 class MakeLocalCallTests(unittest.TestCase):
 
     def test_no_exceptions(self):
-       call = ['ls', '/tmp/']
-       acktools.make_local_call(call)
-        
+        call = ['ls', '/tmp/']
+        acktools.make_local_call(call)
+
     def test_expect_exception(self):
-        call = ['ls','/tmp']
+        call = ['ls', '/tmp']
         real_popen = subprocess.Popen
-        setattr(subprocess, 'Popen', lambda *args, \
+        setattr(subprocess, 'Popen', lambda *args,
                 **kwargs: MockProcess('No such file!', 'No such file!'))
         self.assertRaises(Exception, acktools.make_local_call, call)
         setattr(subprocess, 'Popen', real_popen)
-
 
 
 if __name__ == "__main__":

--- a/acktools/utils.py
+++ b/acktools/utils.py
@@ -3,31 +3,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 
@@ -36,7 +36,7 @@ def cli_table_to_recs(table_string):
     returns a list of records matching the header to values."""
 
     lines = table_string.split('\n')
-    
+
     # Take the first line as the header
     header_line = lines.pop(0).split()
 
@@ -45,5 +45,5 @@ def cli_table_to_recs(table_string):
         vals = line.split()
         rec = dict(zip(header_line, vals))
         route_recs.append(rec)
-    
+
     return route_recs

--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -3,31 +3,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 
@@ -54,12 +54,15 @@ from exceptions import *
 MIN_VLAN = 0
 MAX_VLAN = 4096
 
+
 def get_xapi_session(config):
-    #Future improvement, implement remote login. For now, just return local
+    # Future improvement, implement remote login. For now, just return local
     return utils.get_local_xapi_session()
 
+
 def parse_cmd_args():
-    parser = OptionParser(usage="%prog [options]", version="%prog @KIT_VERSION@")
+    parser = OptionParser(
+        usage="%prog [options]", version="%prog @KIT_VERSION@")
 
     parser.add_option("-d", "--debug",
                       dest="debug",
@@ -71,44 +74,42 @@ def parse_cmd_args():
                       dest="vlan",
                       default="trunk",
                       help="Specify a VLAN tag ID for which your switches have been configured")
-    parser.add_option("-g","--generate",
+    parser.add_option("-g", "--generate",
                       dest="generate",
                       action="store_const",
                       const=True,
                       default=False,
                       help="Generate the config file only. Do not run the tests yet.")
-    parser.add_option("-l","--list",
+    parser.add_option("-l", "--list",
                       dest="list_tests",
                       action="store_const",
                       const=True,
                       default=False,
                       help="List all of the test methods")
-    parser.add_option("-i","--info",
+    parser.add_option("-i", "--info",
                       dest="info",
                       help="Print out information about a specified test name.")
     parser.add_option("-m", "--mode",
                       dest="mode",
                       default="ALL",
                       help="Specify the type of certification you wish to perform. (ALL (default) | NET | LSTOR | CPU | OPS).")
-    parser.add_option("-e","--exclude",
+    parser.add_option("-e", "--exclude",
                       dest="exclude",
                       action="append",
                       default=[],
                       help="Exclude one or multiple set of tests. (OVS | BRIDGE | LSTOR | CPU | OPS | CRASH).")
-    parser.add_option("-n","--netconf",
+    parser.add_option("-n", "--netconf",
                       dest="netconf",
                       help="Specify the network config file.")
     # The option string is an extension, allowing users to specify KVPs
     # e.g. optionstr = "dhcp=True,key1=val1,..."
-    parser.add_option("-o","--option",
+    parser.add_option("-o", "--option",
                       dest="optionstr",
                       help="Specify extra options.")
-
 
     (options, _) = parser.parse_args()
 
     config = {}
-
 
     config['debug'] = options.debug
 
@@ -125,7 +126,8 @@ def parse_cmd_args():
         assert_file_exists(options.netconf, 'Network config')
         config['netconf'] = parse_netconf_file(options.netconf)
     else:
-        raise utils.ArgumentError("You must specify a network configuration file. %s" % options.mode)
+        raise utils.ArgumentError(
+            "You must specify a network configuration file. %s" % options.mode)
 
     config['mode'] = options.mode
     config['exclude'] = options.exclude
@@ -140,6 +142,7 @@ def parse_cmd_args():
 
     return config
 
+
 def kvp_string_to_rec(string):
     """Take an input string 'a=b,c=d,e=f' and return the record
     {'a':'b','c':'d','e':'f'}"""
@@ -151,6 +154,7 @@ def kvp_string_to_rec(string):
         rec[arr[0]] = arr[1]
     return rec
 
+
 def parse_netconf_file(filename):
 
     arrs = utils.read_valid_lines(filename)
@@ -159,8 +163,9 @@ def parse_netconf_file(filename):
     for arr in arrs:
 
         if arr.count('=') != 1:
-            raise Exception("Error: format of netconf file should be 'key = value'")
-        
+            raise Exception(
+                "Error: format of netconf file should be 'key = value'")
+
         key, value = [items.strip() for items in arr.split('=')]
 
         if key.startswith('eth'):
@@ -176,17 +181,17 @@ def parse_netconf_file(filename):
             utils.log.debug("Network IDs: '%s'" % csv[0])
             network_id = int(csv[0])
 
-            #Parse VLAN IDs
+            # Parse VLAN IDs
             try:
                 # Extract bracketed substring
-                vlan_str = arr[arr.index('[')+1:arr.index(']')]
+                vlan_str = arr[arr.index('[') + 1:arr.index(']')]
                 # Convert values to integers
                 vlan_ids = [int(x) for x in vlan_str.split(',')]
                 # Ensure that the specified VLAN is valid
-                for vlan_id in vlan_ids:        
+                for vlan_id in vlan_ids:
                     if vlan_id > MAX_VLAN or vlan_id < MIN_VLAN:
                         raise utils.InvalidArgument('VLAN ID for %s' % arr[0], vlan_id, '%d < x < %d' %
-                                                    (MIN_VLAN, MAX_VLAN))  
+                                                    (MIN_VLAN, MAX_VLAN))
             except ValueError:
                 raise utils.InvalidArgument('VLAN IDs', vlan_str, '%d < x < %d: x = INT' %
                                             (MIN_VLAN, MAX_VLAN))
@@ -203,43 +208,48 @@ def parse_netconf_file(filename):
             if unicode(net.strip()).isdecimal() and unicode(vlan.strip()).isdecimal():
                 rec[key] = parse_static_config(value)
             else:
-                raise Exception("Error: unable to determine network and/or vlan from '%s'" % key)
+                raise Exception(
+                    "Error: unable to determine network and/or vlan from '%s'" % key)
 
         else:
             raise Exception("Error: unable to parse line: '%s'" % arr)
-                        
 
     return rec
+
 
 def assert_file_exists(file_name, label):
     """Check whether a file exists, if it doesn't, raise an exception"""
     if not os.path.isfile(file_name):
         raise utils.ConfigFileNotFound(file_name, label)
 
+
 def validate_param(value, possibles, arg_name):
     """Ensure that the provided value is one of values in the possibles list"""
     if value.upper() not in [string.upper() for string in possibles]:
         raise utils.InvalidArgument(arg_name, value, possibles)
 
+
 def parse_static_config(string):
     """Parse a string specifying static networking config for droid VMs to use.
     The format should be ip_start,ip_end,netmask,gateway."""
     arr = string.split(',')
-    
+
     if len(arr) != 4:
-        raise Exception("The static config string supplied was invalid. It should be of the form: ip_start,ip_end,netmask,gateway. Actually '%s'" % string)
+        raise Exception(
+            "The static config string supplied was invalid. It should be of the form: ip_start,ip_end,netmask,gateway. Actually '%s'" % string)
 
     config = {}
-    
+
     def copy(label, pos):
         config[label] = arr[pos].strip()
-    
+
     copy('ip_start', 0)
-    copy('ip_end',1)
-    copy('netmask',2)
-    copy('gw',3)
+    copy('ip_end', 1)
+    copy('netmask', 2)
+    copy('gw', 3)
 
     return config
+
 
 def network_interfaces_to_test(session, config):
     """Return a list of all the ethernet devices that must be tested by the
@@ -248,25 +258,26 @@ def network_interfaces_to_test(session, config):
 
     # Extract from netconf the network interfaces that the user
     # has specified.
-    ifaces_to_test = [iface.strip() for iface in config['netconf'].keys() 
+    ifaces_to_test = [iface.strip() for iface in config['netconf'].keys()
                       if iface.startswith('eth')]
 
     devices = utils.get_master_network_devices(session)
 
     # Filter the list of devices available on the master by the interfaces
     # specified by the caller in their netconf file.
-    devices_to_test = [dev for dev in devices 
-                      if dev['Kernel_name'] in ifaces_to_test]
-    
+    devices_to_test = [dev for dev in devices
+                       if dev['Kernel_name'] in ifaces_to_test]
+
     device_groups_list = []
     for key, items in itertools.groupby(devices_to_test, operator.itemgetter('PCI_id')):
         device_groups_list.append(list(items))
 
     ifaces = []
     for grp in device_groups_list:
-        dev = grp[0] #we can use any of the devices in the group
-        ifaces.append(dev['Kernel_name']) 
+        dev = grp[0]  # we can use any of the devices in the group
+        ifaces.append(dev['Kernel_name'])
     return ifaces
+
 
 def storage_interfaces_to_test(session):
     """Return a list of all storage interface devices that connected to local
@@ -283,9 +294,9 @@ def storage_interfaces_to_test(session):
     for device in devices:
         for existing in devices_to_test:
             if comp_key(device, existing, 'vendor') and \
-                comp_key(device, existing, 'driver') and \
-                comp_key(device, existing, 'subclass') and \
-                comp_key(device, existing, 'class'):
+                    comp_key(device, existing, 'driver') and \
+                    comp_key(device, existing, 'subclass') and \
+                    comp_key(device, existing, 'class'):
                 break
             if comp_key(device, existing, 'PCI_id'):
                 break
@@ -312,7 +323,7 @@ def generate_test_config(session, config, test_run_file):
     root_node.appendChild(global_config_node)
 
     # Create the XML node under which, each device we are testing
-    # is located. 
+    # is located.
 
     devices_node = doc.createElement('devices')
     root_node.appendChild(devices_node)
@@ -324,7 +335,8 @@ def generate_test_config(session, config, test_run_file):
 
     # Take an interface to use for non-networking tests
     if not len(ifs):
-        raise Exception("Error: in order to run these tests, you need at least one network defined.") 
+        raise Exception(
+            "Error: in order to run these tests, you need at least one network defined.")
 
     xml_generators = list(XML_GENERATORS)
 
@@ -336,64 +348,73 @@ def generate_test_config(session, config, test_run_file):
         utils.log.debug("No ack_addons module found.")
 
     for gen_cls in xml_generators:
-        xml_generator = gen_cls(session, config, config['mode'], ifs, storage_devs)
+        xml_generator = gen_cls(session, config, config[
+                                'mode'], ifs, storage_devs)
         xml_generator.append_xml_config(doc, devices_node)
 
     fh = open(test_run_file, 'w')
     fh.write(doc.toxml())
     fh.close()
 
+
 @utils.log_exceptions
 def pre_flight_checks(session, config):
     """Check for some of the common problems"""
-    
-    #Check for a run in progress
+
+    # Check for a run in progress
     if check_for_process():
-        raise Exception("Error: An ACK process already exists on this host. Kill all running ACK processes and start the test again.")
-    
-    #Check for at least two hosts
+        raise Exception(
+            "Error: An ACK process already exists on this host. Kill all running ACK processes and start the test again.")
+
+    # Check for at least two hosts
     hosts = session.xenapi.host.get_all()
     if len(hosts) < 2:
-        raise Exception("Error: You need to have a pool of at least two hosts to run this kit. Only found %d." % (len(hosts)))
+        raise Exception(
+            "Error: You need to have a pool of at least two hosts to run this kit. Only found %d." % (len(hosts)))
 
     for host in hosts:
         ver = utils.get_ack_version(session, host)
         if not ver:
-            raise Exception("Error: Both hosts need the Auto Cert Kit installed on them! The kit was not found on %s" % host)
+            raise Exception(
+                "Error: Both hosts need the Auto Cert Kit installed on them! The kit was not found on %s" % host)
 
     # Check that each host has some storage
     for host in hosts:
-       avail_storage = utils.find_storage_for_host(session, host)
-       if not avail_storage:
-           raise Exception("Error: host '%s' has no available storage.") 
+        avail_storage = utils.find_storage_for_host(session, host)
+        if not avail_storage:
+            raise Exception("Error: host '%s' has no available storage.")
 
-    #Check that we have at least two network adaptors, on the same network
+    # Check that we have at least two network adaptors, on the same network
     recs = config['netconf']
     ifaces = {}
     for k, v in recs.iteritems():
         if k.startswith('eth'):
             ifaces[k] = v['network_id']
-    
-    utils.log.debug("Network interfaces specified in config file: %s" % ifaces.keys())
+
+    utils.log.debug(
+        "Network interfaces specified in config file: %s" % ifaces.keys())
 
     if 'singlenic' in config.keys() and config['singlenic'] == "true":
-        utils.log.debug("Skipping check for multiple networks, as only a single NIC is being tested")
+        utils.log.debug(
+            "Skipping check for multiple networks, as only a single NIC is being tested")
         return
 
-    #If less than 2 interfaces, raise an exception
+    # If less than 2 interfaces, raise an exception
     if len(ifaces.keys()) < 2:
-        raise Exception("Error: the test kit needs at least 2 network interfaces to be defined in your network config file. Only %d were found: %s" % (len(ifaces.keys()), ifaces.keys()))
+        raise Exception("Error: the test kit needs at least 2 network interfaces to be defined in your network config file. Only %d were found: %s" % (
+            len(ifaces.keys()), ifaces.keys()))
 
-    #If less than 2 interfaces share the same network, raise an exception
+    # If less than 2 interfaces share the same network, raise an exception
     for k, v in ifaces.iteritems():
         if ifaces.values().count(v) < 2:
             raise Exception("Error: ethernet device %s on network %s is defined in the network config but does not have a matching partner. \
                 Please review the nework configuration and minumum requirements of this kit." % (k, v))
-    
+
+
 def main(config, test_run_file):
     """Main routine - assess which tests should be run, and create
     output file"""
-    
+
     session = get_xapi_session(config)
 
     # Release current logger before running logrotate.
@@ -416,18 +437,18 @@ def main(config, test_run_file):
     session.logout()
 
     if 'generate' in config:
-        #Generate config file only
+        # Generate config file only
         utils.log.info("Test file generated")
         return "OK"
 
-    #Kick off the testrunner
+    # Kick off the testrunner
     utils.log.info("Starting Test Runner from ACK CLI.")
     test_file, output = test_runner.run_tests_from_file(test_run_file)
 
 if __name__ == "__main__":
     config = parse_cmd_args()
 
-    #Default config file
+    # Default config file
     test_run_file = 'test_run.conf'
 
     main(config, test_run_file)

--- a/autocertkit/cpu_tests.py
+++ b/autocertkit/cpu_tests.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """Module for CPU specific tests"""
@@ -35,33 +35,34 @@ from utils import *
 
 log = get_logger('auto-cert-kit')
 
+
 class PerfTestClass(testbase.CPUTestClass):
     """A somewhat generic test class for CPU performance tests
     that could be expanded to include additional plugin-based tasks"""
 
-    #Deine the test timeout in seconds and the number of test VMs
+    # Deine the test timeout in seconds and the number of test VMs
     timeout = 3600
     vm_count = 3
-    
-    #SSH command variables
+
+    # SSH command variables
     username = 'root'
     password = DEFAULT_PASSWORD
-    
-    #Class variables
+
+    # Class variables
     test = ''
     cmd_str = ''
-    
+
     def _setup_vms(self, session):
         """Create vm_count VMs on the master host and
         return a list of VM ref objects"""
         host_ref = get_pool_master(session)
         net_ref = get_management_network(session)
-        return deploy_count_droid_vms_on_host(session, 
-                                              host_ref, 
-                                              [net_ref], 
+        return deploy_count_droid_vms_on_host(session,
+                                              host_ref,
+                                              [net_ref],
                                               self.vm_count,
                                               {net_ref: self.get_static_manager(net_ref)})
-        
+
     def _call_plugin(self, session, vm_ref_list, call):
         """Generic plugin call modified for this test class"""
         res = []
@@ -71,54 +72,56 @@ class PerfTestClass(testbase.CPUTestClass):
                                         'username': self.username,
                                         'password': self.password}))
         return res
-    
-    def _create_test_threads(self, session, vm_ref_list):    
+
+    def _create_test_threads(self, session, vm_ref_list):
         """Spawns a new non-blocking test thread for each VM and 
         returns a reference object to these threads.  Each thread is
         a timeout function of function self.cmd_str which is run on
         the master host by the XenAPI plugin"""
         threads = []
-        for vm_ref in vm_ref_list:    
+        for vm_ref in vm_ref_list:
             vm_ip = wait_for_ip(session, vm_ref, 'eth0')
             threads.append(create_test_thread(lambda: TimeoutFunction(ssh_command(vm_ip,
                                                                                   self.username,
                                                                                   self.password,
                                                                                   self.cmd_str),
                                                                       self.timeout, '%s test timed out %d' % (self.test, self.timeout))))
-        return threads         
+        return threads
 
     def _run_test(self, session):
         """Main run fuction.  Sets up the VMs, deploys the test,
         spawns the test threads, and tracks the threads until they
         all complete"""
-        #setup vms
+        # setup vms
         vm_ref_list = self._setup_vms(session)
 
-        #Make certain the VMs are available
+        # Make certain the VMs are available
         for vm_ref in vm_ref_list:
             check_vm_ping_response(session, vm_ref)
-                
-        #deploy test rpms
+
+        # deploy test rpms
         log.debug("Deploying test RPMs")
         self._call_plugin(session, vm_ref_list, 'deploy_' + self.test)
-        
-        #create and start test threads, wait until complete
+
+        # create and start test threads, wait until complete
         log.debug("About to run %s test..." % self.test)
         threads = self._create_test_threads(session, vm_ref_list)
-        
-        #Wait for the threads to finish running or timeout
+
+        # Wait for the threads to finish running or timeout
         start = time.time()
-        while check_test_thread_status(threads): 
+        while check_test_thread_status(threads):
             time.sleep(1)
             if should_timeout(start, self.timeout):
-                raise Exception("%s test timed out %s" % (self.test, self.timeout))
-        
-        #retrieve the logs
+                raise Exception("%s test timed out %s" %
+                                (self.test, self.timeout))
+
+        # retrieve the logs
         log.debug("%s test is complete, retrieving logs" % self.test)
-        res = self._call_plugin(session, vm_ref_list, 'retrieve_' + self.test + '_logs')
+        res = self._call_plugin(session, vm_ref_list,
+                                'retrieve_' + self.test + '_logs')
 
         return {'info': 'Test ran successfully'}
-    
+
     def test_lmbench(self, session):
         """Perform the LMBench CPU benchmark"""
         self.test = 'lmbench'

--- a/autocertkit/models.py
+++ b/autocertkit/models.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """Module for providing python object models for the XML config/test files"""
@@ -34,6 +34,7 @@ from xml.dom import minidom
 from utils import *
 
 import operator
+
 
 def get_attributes(xml_node):
     """ When given an XML node, return a dictionary object
@@ -48,9 +49,11 @@ def get_attributes(xml_node):
 
     return rec
 
+
 def get_child_elems(xml_node):
     return [node for node in xml_node.childNodes
-             if node.nodeType == node.ELEMENT_NODE]
+            if node.nodeType == node.ELEMENT_NODE]
+
 
 def remove_child_nodes(parent_node):
     while parent_node.hasChildNodes():
@@ -70,7 +73,7 @@ class Element(object):
             self.set_value(value)
         if attributes:
             self.set_attributes(attributes)
-        
+
     def get_name(self):
         return self.name
 
@@ -83,10 +86,10 @@ class Element(object):
     def create_xml_node(self, dom):
         """Create the xml node representation of this object"""
         xml_node = dom.createElement(str(self.get_name()))
-        
+
         # Set the elements XML attributes
-        for k,v in self.attr.iteritems():
-            xml_node.setAttribute(str(k),str(v))
+        for k, v in self.attr.iteritems():
+            xml_node.setAttribute(str(k), str(v))
 
         # Set the elements value
         if self.val:
@@ -97,6 +100,7 @@ class Element(object):
 
 
 class XMLNode(Element):
+
     def __init__(self, node):
         self.name = node.tagName
         self.attr = get_attributes(node)
@@ -150,36 +154,36 @@ class DeviceTestClassMethod(object):
         """ This method has not been executed yet. """
         return self._match_result('NULL')
 
-    def create_xml_node(self,dom):
+    def create_xml_node(self, dom):
         """Write this test method out to an xml node"""
         xml_node = dom.createElement('test_method')
         for k, v in self.attr.iteritems():
             xml_node.setAttribute(str(k), str(v))
-        
+
         for elem in self.elems:
             node = elem.create_xml_node(dom)
             xml_node.appendChild(node)
 
         return xml_node
-            
+
     def update_elem(self, k, v):
         for elem in self.elems:
             if elem.get_name() == k:
-                
+
                 if type(v) is dict:
                     elem.set_attributes(v)
                 else:
                     elem.set_value(v)
                 return
-        
+
         # Element does not already exist, so create it.
 
         if type(v) is dict:
-            new_el = Element(k,None, v)
+            new_el = Element(k, None, v)
         else:
-            new_el = Element(k,v,None)
-        
-        #Ensure we don't update all of the element classes
+            new_el = Element(k, v, None)
+
+        # Ensure we don't update all of the element classes
         elem_list = list(self.elems)
         elem_list.append(new_el)
         self.elems = elem_list
@@ -188,6 +192,7 @@ class DeviceTestClassMethod(object):
         """Update elements in this method object from a provided record"""
         for k, v in rec.iteritems():
             self.update_elem(k, v)
+
 
 class DeviceTestClass(object):
     """Model for a test class"""
@@ -202,7 +207,7 @@ class DeviceTestClass(object):
         for method_node in get_child_elems(testclass_node):
             method_list.append(DeviceTestClassMethod(self, method_node))
         self.test_methods = method_list
-    
+
     def get_caps(self):
         """ Return a list of caps supported by this
         device based on the tests that have passed/failed """
@@ -214,7 +219,7 @@ class DeviceTestClass(object):
         classes bear the same integer order, there is no strict ordering between
         them"""
         return self.config['order']
-    
+
     def has_passed(self):
         for method in self.get_methods():
             if not method.has_passed() and self.is_required():
@@ -231,7 +236,7 @@ class DeviceTestClass(object):
 
     def get_methods_to_run(self):
         return sorted([method for method in self.test_methods if method.is_waiting()],
-                    key=lambda a: a.get_name())
+                      key=lambda a: a.get_name())
 
     def get_method_by_name(self, name):
         """Note, the method name is unique"""
@@ -249,7 +254,7 @@ class DeviceTestClass(object):
                 if test_name in method.get_name():
                     return method
             raise Exception("test_name %s is given, but cannot find it from waiting method list of test class %s"
-                % (test_name, self.get_name()))
+                            % (test_name, self.get_name()))
 
         if not test_methods:
             return None
@@ -275,8 +280,8 @@ class DeviceTestClass(object):
         for result in results:
             method = self.get_method_by_name(result['test_name'])
             if not method:
-                raise Exception("Error: the method '%s' doesn't belong to the TestClass '%s'" % 
-                                (result['test_name'], self.get_name() ))
+                raise Exception("Error: the method '%s' doesn't belong to the TestClass '%s'" %
+                                (result['test_name'], self.get_name()))
             method.update(result)
 
     def save(self, filename):
@@ -298,11 +303,13 @@ class DeviceTestClass(object):
                             (self.get_name(), self.parent.udid, filename))
 
         # Find the node belonging to this test class by matching name
-        node_list = [node for node in tc_nodes if node.getAttribute('name') == self.get_name()]
+        node_list = [node for node in tc_nodes if node.getAttribute(
+            'name') == self.get_name()]
 
         # Check for the existence of *only one* node
         if len(node_list) != 1:
-            raise Exception("Error: Expecting there not to be test class duplicates. '%s'" % node_list)
+            raise Exception(
+                "Error: Expecting there not to be test class duplicates. '%s'" % node_list)
         # Take the only node
         class_node = node_list.pop()
 
@@ -318,11 +325,11 @@ class DeviceTestClass(object):
         fh = open(filename, 'w')
         fh.write(dom.toxml())
         fh.close()
-        
-        return "OK"
-                
 
-class Device(object):    
+        return "OK"
+
+
+class Device(object):
     """Model for a device object that would be added to HCL"""
     udid = None
     config = None
@@ -333,24 +340,25 @@ class Device(object):
         and converting into this model"""
         self.config = get_attributes(xml_device_node)
         self.tag = self.config['tag']
-        self.udid = self.config['udid'] #Unique device id
-    
+        self.udid = self.config['udid']  # Unique device id
+
         # We only care about child element nodes
         childElems = [node for node in xml_device_node.childNodes
                       if node.nodeType == node.ELEMENT_NODE]
 
         # We expect there to be one child node 'certification_tests'
         if len(childElems) != 1:
-            raise Exception("Error: unexpected XML format. Should only be one child node: %s" % childElems)
-        
+            raise Exception(
+                "Error: unexpected XML format. Should only be one child node: %s" % childElems)
+
         xml_cert_tests_node = childElems[0]
 
         test_class_list = []
         for test_node in get_child_elems(xml_cert_tests_node):
-            test_class_list.append(DeviceTestClass(self,test_node))
+            test_class_list.append(DeviceTestClass(self, test_node))
         self.test_classes = test_class_list
-        
-    def get_test_results(self, filter_required = None):
+
+    def get_test_results(self, filter_required=None):
         """Return a list of test methods"""
         res = []
         for test_class in self.test_classes:
@@ -383,7 +391,7 @@ class Device(object):
         if (self.tag == "NA" or self.tag == "LS") and "PCI_subsystem" in self.config:
             return self.config["PCI_subsystem"]
         return ""
-        
+
     def get_description(self):
         """Depending on the type, return the appropriate description
         for this device"""
@@ -393,7 +401,8 @@ class Device(object):
             if self.tag == "CPU":
                 return self.config['modelname']
             if self.tag == "LS":
-                LS_info = "Storage device using the %s driver" % self.config['driver']
+                LS_info = "Storage device using the %s driver" % self.config[
+                    'driver']
                 if 'PCI_description' in self.config:
                     LS_info += "\n\t%s" % self.config['PCI_description']
                 return LS_info
@@ -418,12 +427,13 @@ class Device(object):
             if supported:
                 for cap in tcaps:
                     if not cap in caps.keys():
-                        #Only update, if not in rec. Since it's
-                        #supported by this case, if a previous result
-                        #has set the cap to false, we should not override that.
+                        # Only update, if not in rec. Since it's
+                        # supported by this case, if a previous result
+                        # has set the cap to false, we should not override
+                        # that.
                         caps[cap] = True
             else:
-                #Not supported case
+                # Not supported case
                 for cap in tcaps:
                     caps[cap] = False
 
@@ -442,8 +452,8 @@ class Device(object):
         can be posted on the HCL."""
 
         # Look through the test classes for this device,
-        # and if any of them have no passed (i.e. not passed 
-        # required 
+        # and if any of them have no passed (i.e. not passed
+        # required
         for test_class in self.test_classes:
             if test_class.is_required() and not test_class.has_passed():
                 return False
@@ -453,13 +463,16 @@ class Device(object):
         """Return number of tests that have passed, failed and are waiting to be
         executed"""
 
-        tests_passed = [tm for tm in self.get_test_results() if tm.has_passed()]
-        tests_failed = [tm for tm in self.get_test_results() if tm.has_failed()]
-        tests_skipped = [tm for tm in self.get_test_results() if tm.has_skipped()]
-        tests_waiting = [tm for tm in self.get_test_results() if tm.is_waiting()]
+        tests_passed = [tm for tm in self.get_test_results()
+                        if tm.has_passed()]
+        tests_failed = [tm for tm in self.get_test_results()
+                        if tm.has_failed()]
+        tests_skipped = [tm for tm in self.get_test_results()
+                         if tm.has_skipped()]
+        tests_waiting = [tm for tm in self.get_test_results()
+                         if tm.is_waiting()]
 
         return len(tests_passed), len(tests_failed), len(tests_skipped), len(tests_waiting)
-        
 
     def print_report(self, stream):
         """Write a report for the device specified"""
@@ -474,24 +487,26 @@ class Device(object):
         tests_passed = [test_method for test_method in self.get_test_results()
                         if test_method.has_passed()]
         tests_failed_req = [test_method for test_method in self.get_test_results(False)
-                        if test_method.has_failed()]
+                            if test_method.has_failed()]
         tests_failed_noreq = [test_method for test_method in self.get_test_results(True)
-                        if test_method.has_failed()]
+                              if test_method.has_failed()]
         tests_skipped_req = [test_method for test_method in self.get_test_results(False)
-                        if test_method.has_skipped()]
+                             if test_method.has_skipped()]
         tests_skipped_noreq = [test_method for test_method in self.get_test_results(True)
-                        if test_method.has_skipped()]
+                               if test_method.has_skipped()]
 
         if not self.has_passed():
-            stream.write("This device has not passed all the neccessary tests and so will not be supported.")
-            stream.write("In order for this device to be supported, this device must pass the following tests:\n")
+            stream.write(
+                "This device has not passed all the neccessary tests and so will not be supported.")
+            stream.write(
+                "In order for this device to be supported, this device must pass the following tests:\n")
             for method in tests_failed_req:
                 stream.write("%s\n" % method.get_name())
             for method in tests_skipped_req:
                 stream.write("%s\n" % method.get_name())
         else:
             stream.write("Capabilities:\n")
-            for k,v in self.get_caps().iteritems():
+            for k, v in self.get_caps().iteritems():
                 if v:
                     reqval = "Supported"
                 else:
@@ -508,19 +523,20 @@ class Device(object):
         if tests_failed_req:
             stream.write("\nTests that failed:\n")
             for test in tests_failed_req:
-                stream.write("%s\n" % test.name)    
+                stream.write("%s\n" % test.name)
 
         if tests_failed_noreq:
             stream.write("\nNone required tests that failed:\n")
             for test in tests_failed_noreq:
-                stream.write("%s\n" % test.name)    
+                stream.write("%s\n" % test.name)
 
         if tests_skipped_req or tests_skipped_noreq:
             stream.write("\nTests that skipped:\n")
             for test in tests_skipped_req:
-                stream.write("%s\n" % test.name)    
+                stream.write("%s\n" % test.name)
             for test in tests_skipped_noreq:
-                stream.write("%s\n" % test.name)    
+                stream.write("%s\n" % test.name)
+
 
 class AutoCertKitRun(object):
     """Python class for representing the XML config file as an object"""
@@ -530,13 +546,14 @@ class AutoCertKitRun(object):
 
     def __init__(self, xml_file):
         dom = minidom.parse(xml_file)
-        
+
         gcns = dom.getElementsByTagName('global_config')
         # We only expect one global_config xml_node
         if len(gcns) != 1:
             log.debug("Found global_config nodes: %s" % gcns)
-            raise Exception("Unexpected XML file format. Found %d global_config nodes." % len(gcns))
-        
+            raise Exception(
+                "Unexpected XML file format. Found %d global_config nodes." % len(gcns))
+
         self.config = get_attributes(gcns[0])
 
         device_nodes = dom.getElementsByTagName('device')
@@ -552,7 +569,7 @@ class AutoCertKitRun(object):
         """Return the number of tests across all devices that have passed, failed and
         are waiting to be executed."""
         passed = 0
-        failed = 0 
+        failed = 0
         skipped = 0
         waiting = 0
         for device in self.devices:
@@ -562,10 +579,10 @@ class AutoCertKitRun(object):
             skipped = skipped + s
             waiting = waiting + w
         return passed, failed, skipped, waiting
-    
+
     def is_finished(self):
         """Return true if the test run has finished"""
-        _,_,_,w = self.get_status()
+        _, _, _, w = self.get_status()
         return not w
 
     def get_next_test_class(self, tc_info=None):
@@ -594,7 +611,8 @@ class AutoCertKitRun(object):
 
         if not tcs_to_run:
             if tc_info:
-                raise Exception("REBOOT_FLAG is set but cannot find matching test case.")
+                raise Exception(
+                    "REBOOT_FLAG is set but cannot find matching test case.")
             return None
 
         # Sort the list according the the integer priorities
@@ -611,9 +629,9 @@ def create_models(xml_file):
     """Create the python object model from a given XML file"""
 
     dom = minidom.parse(xml_file)
-    
+
     device_nodes = dom.getElementsByTagName('device')
-    
+
     device_list = []
 
     for device_node_xml in device_nodes:

--- a/autocertkit/network_tests.py
+++ b/autocertkit/network_tests.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """A module for network specific tests"""
@@ -38,8 +38,10 @@ import math
 
 log = get_logger('auto-cert-kit')
 
+
 class FixedOffloadException(Exception):
     pass
+
 
 class IperfTest:
     """Utility class for running an Iperf test between two VMs
@@ -51,14 +53,14 @@ class IperfTest:
                       'buffer_length': '256K',
                       'thread_count': '1'}
 
-    def __init__(self, session, 
-                       client_vm_ref, 
-                       server_vm_ref, 
-                       network_ref,
-                       static_manager,
-                       username='root', 
-                       password=DEFAULT_PASSWORD, 
-                       config=None):
+    def __init__(self, session,
+                 client_vm_ref,
+                 server_vm_ref,
+                 network_ref,
+                 static_manager,
+                 username='root',
+                 password=DEFAULT_PASSWORD,
+                 config=None):
 
         self.session = session
         self.server = server_vm_ref
@@ -78,8 +80,8 @@ class IperfTest:
 
         self.timeout = 60
 
-        #Validate the references and setup run method
-        #self.validate_refs()
+        # Validate the references and setup run method
+        # self.validate_refs()
 
     def validate_refs(self):
         """Check that the specified references are valid,
@@ -92,7 +94,6 @@ class IperfTest:
         """Record the interface statistics before running any tests"""
         self.stats_rec = {self.client: self.get_iface_stats(self.client),
                           self.server: self.get_iface_stats(self.server)}
-
 
     def validate_stats(self, bytes_sent):
         # Load previous
@@ -121,33 +122,35 @@ class IperfTest:
         # packets over the correct interface
 
         self.plugin_call('reset_arp',
-                    {'vm_ref': self.client,
-                    })
+                         {'vm_ref': self.client,
+                          })
 
         self.plugin_call('reset_arp',
-                    {'vm_ref': self.server,
-                    })
-        
+                         {'vm_ref': self.server,
+                          })
+
         # Make a plugin call to add a route to the client
         self.plugin_call('add_route',
-                   {'vm_ref': self.client,
-                    'dest_ip': self.get_server_ip(self.get_device_name(self.server)),
-                    'dest_mac': get_vm_device_mac(self.session,
-                                                  self.server,
-                                                  self.get_device_name(self.server),
-                                                  ),
-                    'device': self.get_device_name(self.client)}
-                    )
+                         {'vm_ref': self.client,
+                          'dest_ip': self.get_server_ip(self.get_device_name(self.server)),
+                          'dest_mac': get_vm_device_mac(self.session,
+                                                        self.server,
+                                                        self.get_device_name(
+                                                            self.server),
+                                                        ),
+                          'device': self.get_device_name(self.client)}
+                         )
 
         self.plugin_call('add_route',
-                    {'vm_ref': self.server,
-                    'dest_ip': self.get_client_ip(self.get_device_name(self.client)),
-                    'dest_mac': get_vm_device_mac(self.session,
-                                                  self.client,
-                                                  self.get_device_name(self.client),
-                                                  ),
-                    'device': self.get_device_name(self.server)}
-                    )
+                         {'vm_ref': self.server,
+                          'dest_ip': self.get_client_ip(self.get_device_name(self.client)),
+                          'dest_mac': get_vm_device_mac(self.session,
+                                                        self.client,
+                                                        self.get_device_name(
+                                                            self.client),
+                                                        ),
+                          'device': self.get_device_name(self.server)}
+                         )
 
     def run(self):
         """This classes run test function"""
@@ -164,13 +167,13 @@ class IperfTest:
         # Capture interface statistics pre test run
         self.record_stats()
 
-        iperf_test_inst = TimeoutFunction(self.run_iperf_client, 
+        iperf_test_inst = TimeoutFunction(self.run_iperf_client,
                                           self.timeout,
                                           'iPerf test timed out %d' % self.timeout)
 
         # Run the iperf tests
         iperf_data = iperf_test_inst()
-    
+
         # Capture interface statistcs post test run
         bytes_transferred = int(iperf_data['transfer'])
         self.validate_stats(bytes_transferred)
@@ -188,7 +191,7 @@ class IperfTest:
             # Handle Dom0 Case
             host_ref = self.session.xenapi.VM.get_resident_on(self.server)
             ip = call_ack_plugin(self.session, 'get_local_device_ip',
-                                 {'device':iface}, host_ref)
+                                 {'device': iface}, host_ref)
             return ip
 
         else:
@@ -209,11 +212,11 @@ class IperfTest:
                              {'vm_ref': vm_ref,
                               'username': self.username,
                               'password': self.password})
-                             
+
         deploy(self.client)
         deploy(self.server)
 
-    def get_device_name(self, vm_ref): 
+    def get_device_name(self, vm_ref):
         vm_host = self.session.xenapi.VM.get_resident_on(vm_ref)
 
         if self.session.xenapi.VM.get_is_control_domain(vm_ref):
@@ -223,38 +226,40 @@ class IperfTest:
             for pif in pifs:
                 host_ref = self.session.xenapi.PIF.get_host(pif)
                 if vm_host == host_ref:
-                    device_names.append(self.session.xenapi.PIF.get_device(pif))
-                  
+                    device_names.append(
+                        self.session.xenapi.PIF.get_device(pif))
+
             if len(device_names) > 1:
-                raise Exception("Error: expected only a single device " + \
-                                "name to be found in PIF list ('%s') " + \
-                                "Instead, '%s' were returned." % 
-                                                (pifs, device_names))
+                raise Exception("Error: expected only a single device " +
+                                "name to be found in PIF list ('%s') " +
+                                "Instead, '%s' were returned." %
+                                (pifs, device_names))
             device_name = device_names.pop()
             # For control domains, only deal with bridges
-            device_name = device_name.replace('eth','xenbr')
+            device_name = device_name.replace('eth', 'xenbr')
 
         else:
             # Handle the case where we are dealing with a VM
             vm_vifs = self.session.xenapi.VM.get_VIFs(vm_ref)
 
-            filtered_vifs = [vif for vif in vm_vifs \
-                      if self.session.xenapi.VIF.get_device(vif) != '0']
+            filtered_vifs = [vif for vif in vm_vifs
+                             if self.session.xenapi.VIF.get_device(vif) != '0']
 
             network_vifs = self.session.xenapi.network.get_VIFs(self.network)
-    
-            int_vifs = intersection(filtered_vifs, network_vifs) 
+
+            int_vifs = intersection(filtered_vifs, network_vifs)
 
             if len(int_vifs) > 1:
-                raise Exception("Error: more than one VIF connected " + \
+                raise Exception("Error: more than one VIF connected " +
                                 "to VM '%s' ('%s')" % (int_vifs, filtered_vifs))
 
             device_name = "eth%s" % \
                           self.session.xenapi.VIF.get_device(int_vifs.pop())
 
-        log.debug("Device under test for VM %s is '%s'" % (vm_ref, device_name))
-        return device_name 
-    
+        log.debug("Device under test for VM %s is '%s'" %
+                  (vm_ref, device_name))
+        return device_name
+
     def get_iface_stats(self, vm_ref):
         device_name = self.get_device_name(vm_ref)
 
@@ -283,7 +288,7 @@ class IperfTest:
                 args['ip_netmask'] = ip.netmask
             else:
                 args['mode'] = 'dhcp'
-            
+
             host_ref = self.session.xenapi.VM.get_resident_on(vm_ref)
             call_ack_plugin(self.session,
                             'configure_local_device',
@@ -291,7 +296,6 @@ class IperfTest:
                             host=host_ref)
         else:
             log.debug("Client VM is a droid VM, no need to configure an IP")
-
 
     def run_iperf_server(self):
         """Start the iPerf server listening on a VM"""
@@ -311,14 +315,14 @@ class IperfTest:
                 args['mode'] = 'dhcp'
 
             call_ack_plugin(self.session,
-                           'start_iperf_server', 
+                            'start_iperf_server',
                             args,
                             host=host_ref)
         else:
             m_ip_address = self.get_server_ip('eth0')
             test_ip = self.get_server_ip()
             cmd_str = "iperf -s -D -B %s < /dev/null >&/dev/null" % test_ip
-            ssh_command(m_ip_address, self.username, self.password, cmd_str)    
+            ssh_command(m_ip_address, self.username, self.password, cmd_str)
 
     def parse_iperf_line(self, data):
         """Take a CSV line from iperf, parse, returning a dictionary"""
@@ -353,52 +357,53 @@ class IperfTest:
         def copy(param, arg_str):
             if param in self.config.keys() and self.config[param]:
                 params.append(arg_str % self.config[param])
-        
+
         copy('window_size', '-w %s')
         copy('buffer_length', '-l %s')
         copy('format', '-f %s')
         copy('thread_count', '-P %s')
-        
-        cmd_str = "iperf -y csv %s -m -c %s" % (" ".join(params), self.get_server_ip())
+
+        cmd_str = "iperf -y csv %s -m -c %s" % (
+            " ".join(params), self.get_server_ip())
         return cmd_str
 
     def run_iperf_client(self):
         """Run test iperf command on droid VM"""
         log.debug("Starting IPerf client")
         if self.session.xenapi.VM.get_is_control_domain(self.client):
-            #Run client via XAPI plugin
-            log.debug("Executing iperf test from Dom0 (%s (%s) --> %s (%s))" % \
-                (self.session.xenapi.VM.get_name_label(self.client), 
-                self.client,
-                self.session.xenapi.VM.get_name_label(self.server),
-                self.server))
+            # Run client via XAPI plugin
+            log.debug("Executing iperf test from Dom0 (%s (%s) --> %s (%s))" %
+                      (self.session.xenapi.VM.get_name_label(self.client),
+                       self.client,
+                       self.session.xenapi.VM.get_name_label(self.server),
+                       self.server))
 
             args = {}
 
             def copy(param):
                 if param in self.config.keys() and self.config[param]:
                     args[param] = self.config[param]
-            
+
             copy('window_size')
             copy('format')
             copy('buffer_length')
             copy('thread_count')
             args['dst'] = self.get_server_ip()
-            args['vm_ref'] = self.client        
+            args['vm_ref'] = self.client
 
             result = self.plugin_call('iperf_test', args)
         else:
-            #Run the client locally
+            # Run the client locally
             cmd_str = self.get_iperf_command()
-            result = ssh_command(self.get_client_ip(), self.username, self.password, cmd_str)
+            result = ssh_command(self.get_client_ip(),
+                                 self.username, self.password, cmd_str)
         return self.parse_iperf_line(result)
 
-    
 
 class VLANTestClass(testbase.NetworkTestClass):
     """A test class for ensuring that hardware
     can cope with VLAN traffic correctly"""
-    
+
     required_config = ['device_config', 'vlan_id']
     tags = ['DEMO']
     default_vlan = 800
@@ -412,9 +417,9 @@ class VLANTestClass(testbase.NetworkTestClass):
 
         devices = self.get_pifs_to_use()
 
-        #Take just the first available device to test
+        # Take just the first available device to test
         device = devices[0]
-        
+
         vlans = self.get_vlans(device)
         vlans.sort()
         vlan_id = vlans.pop()
@@ -425,9 +430,9 @@ class VLANTestClass(testbase.NetworkTestClass):
 
         for pif_ref in get_pifs_by_device(session, device):
             log.debug("Creating VLAN for PIF %s" % pif_ref)
-            log.debug("Network ref = %s vlan_id = %s" % 
+            log.debug("Network ref = %s vlan_id = %s" %
                       (vlan_network_ref, vlan_id))
-            create_vlan(session, pif_ref, 
+            create_vlan(session, pif_ref,
                         vlan_network_ref, vlan_id)
 
         log.debug("VLAN for PIF created")
@@ -438,10 +443,12 @@ class VLANTestClass(testbase.NetworkTestClass):
         # We may want to allocate static addresses to the different interfaces
         # differently, so collect the static ip managers in a record.
         sms = {}
-        sms[management_network_ref] = self.get_static_manager(management_network_ref)
-        sms[vlan_network_ref] = self.get_static_manager(vlan_network_ref, vlan=vlan_id)
-        
-        #Deploy two VMs
+        sms[management_network_ref] = self.get_static_manager(
+            management_network_ref)
+        sms[vlan_network_ref] = self.get_static_manager(
+            vlan_network_ref, vlan=vlan_id)
+
+        # Deploy two VMs
         vm1_ref, vm2_ref = deploy_two_droid_vms(session, network_refs, sms)
 
         vm1_ip = wait_for_ip(session, vm1_ref, 'eth0')
@@ -459,14 +466,14 @@ class VLANTestClass(testbase.NetworkTestClass):
             dhcp = False
 
         log.debug("About to configure network interfaces over SSH")
-       
+
         vm2_eth1_ip = wait_for_ip(session, vm2_ref, 'eth1')
 
-        #Make certain the VMs are available
+        # Make certain the VMs are available
         for vm_ref in [vm1_ref, vm2_ref]:
             check_vm_ping_response(session, vm_ref)
-                
-        #Run Ping Command
+
+        # Run Ping Command
         ping_result = ping(vm1_ip, vm2_eth1_ip, 'eth1')
         log.debug("Result: %s" % ping_result)
 
@@ -474,18 +481,19 @@ class VLANTestClass(testbase.NetworkTestClass):
         rec['info'] = ping_result
 
         if "0% packet loss" not in ping_result:
-            raise TestCaseError("Error: Ping transmittion failed. %s" 
+            raise TestCaseError("Error: Ping transmittion failed. %s"
                                 % ping_result)
 
         return rec
+
 
 class BondingTestClass(testbase.NetworkTestClass):
     """A test class for ensuring that hardware
         can cope with network bonding correctly"""
 
-    required_config = ['device_config']  
+    required_config = ['device_config']
     num_ips_required = 2
-            
+
     def _setup_network(self, session, mode):
         """Util function for creating a pool-wide network, 
             NIC bond of specified mode on each host"""
@@ -495,26 +503,28 @@ class BondingTestClass(testbase.NetworkTestClass):
 
         # Use the first physical interface returned
         self.piface = self.get_primary_bond_iface()[0]
-        # Use the first bondable interface for the specified physical interface above 
+        # Use the first bondable interface for the specified physical interface
+        # above
         self.siface = self.get_bondable_ifaces(self.piface)[0]
-        
+
         # Organize the correct PIF ref sets
         pifs_ref_set_by_host = []
         for host in session.xenapi.host.get_all():
             pif1 = get_pifs_by_device(session, self.piface, [host])
             pif2 = get_pifs_by_device(session, self.siface, [host])
             pifs_ref_set_by_host.append(pif1 + pif2)
-            
+
         # Create nic bond
         for pifs_ref_set in pifs_ref_set_by_host:
-            log.debug("Bonding PIF set %s to network %s" % (pifs_ref_set, net_ref))
+            log.debug("Bonding PIF set %s to network %s" %
+                      (pifs_ref_set, net_ref))
             create_nic_bond(session, net_ref, pifs_ref_set, '', mode)
-        #Ensure that hosts come back online after creating these bonds.
+        # Ensure that hosts come back online after creating these bonds.
         wait_for_hosts(session)
 
         management_network_ref = get_management_network(session)
         return [management_network_ref, net_ref]
-                    
+
     def _setup_vms(self, session, net_refs):
         """Util function for returning VMs to run bonding test on"""
         log.debug("Setting up droid vms...")
@@ -526,7 +536,7 @@ class BondingTestClass(testbase.NetworkTestClass):
             sms[net_ref] = self.get_static_manager(net_ref)
 
         return deploy_two_droid_vms(session, net_refs, sms)
-        
+
     def _run_test(self, session, mode):
         """Test control method for configuring the NIC bond,
             configuring the test VMs, and testing for an active 
@@ -538,42 +548,42 @@ class BondingTestClass(testbase.NetworkTestClass):
         vm2_bondnic_ip = wait_for_ip(session, vm2_ref, 'eth1')
 
         for vm_ref in [vm1_ref, vm2_ref]:
-            check_vm_ping_response(session,vm_ref)
-    
+            check_vm_ping_response(session, vm_ref)
+
         log.debug("Starting test...")
         results = []
-        #Test healthy bond
+        # Test healthy bond
         results.append(ping(vm1_ip, vm2_bondnic_ip, 'eth1'))
-        
-        #Test degraded bond
+
+        # Test degraded bond
         set_nic_device_status(session, self.piface, 'down')
         results.append(ping(vm1_ip, vm2_bondnic_ip, 'eth1'))
-        
-        #Test degraded bond
+
+        # Test degraded bond
         set_nic_device_status(session, self.piface, 'up')
         set_nic_device_status(session, self.siface, 'down')
         results.append(ping(vm1_ip, vm2_bondnic_ip, 'eth1'))
-        
+
         set_nic_device_status(session, self.siface, 'up')
-       
+
         rec = {}
         rec['data'] = results
         rec['config'] = mode
-       
+
         for result in results:
             if not valid_ping_response(result, 20):
-                raise TestCaseError("Error: Ping transmittion failed for bond type: %s. %s" 
+                raise TestCaseError("Error: Ping transmittion failed for bond type: %s. %s"
                                     % (mode, result))
             else:
                 log.debug("Ping Result: %s" % result)
-                
+
         return rec
-    
+
     def test_nic_bond_balance_slb(self, session):
         """NIC bonding test case for balance-slb type bond"""
         log.debug("Starting to run test_nic_bond_balance_slb...")
         return self._run_test(session, 'balance-slb')
-    
+
     def test_nic_bond_active_backup(self, session):
         """NIC bonding test class for active-backup type bond"""
         log.debug("Starting to run test_nic_bond_active_backup...")
@@ -592,7 +602,7 @@ class IperfTestClass(testbase.NetworkTestClass):
                   'thread_count': '4'}
 
     required_config = ['device_config']
-    network_for_test = None 
+    network_for_test = None
     num_ips_required = 2
     mode = "vm-vm"
 
@@ -617,7 +627,7 @@ class IperfTestClass(testbase.NetworkTestClass):
         can be subclassed to run different configurations"""
         log.debug("Setting up VM - VM cross host test")
 
-        # Setup default static manager with the available interfaces    
+        # Setup default static manager with the available interfaces
         sms = {}
         for network_ref in network_refs:
             sms[network_ref] = self.get_static_manager(network_ref)
@@ -631,7 +641,7 @@ class IperfTestClass(testbase.NetworkTestClass):
         sms = {}
         for network_ref in network_refs:
             sms[network_ref] = self.get_static_manager(network_ref)
-    
+
         log.debug("Create droid")
         vm2_ref = deploy_slave_droid_vm(session, network_refs, sms)
         log.debug("droid created")
@@ -647,8 +657,8 @@ class IperfTestClass(testbase.NetworkTestClass):
     def _run_test(self, session, direction):
 
         log.debug("Testing with mode %s" % direction)
-        
-        #Use the first available network to run tests on
+
+        # Use the first available network to run tests on
         network_refs = self._setup_network(session)
 
         if self.mode == "vm-vm":
@@ -678,22 +688,24 @@ class IperfTestClass(testbase.NetworkTestClass):
             attempt_count += 1
             try:
                 log.debug("About to run iperf test...")
-                #Run an iperf test - if failure, an exception should be raised.
+                # Run an iperf test - if failure, an exception should be
+                # raised.
                 iperf_data = IperfTest(session, client, server,
-                                self.network_for_test,
-                                self.get_static_manager(self.network_for_test),
-                                config=self.IPERF_ARGS).run()
+                                       self.network_for_test,
+                                       self.get_static_manager(
+                                           self.network_for_test),
+                                       config=self.IPERF_ARGS).run()
             except Exception, e:
                 log.warning(str(e))
-                fail_data["failed_attempt_%d"%(attempt_count)]=str(e)
+                fail_data["failed_attempt_%d" % (attempt_count)] = str(e)
             else:
                 break
         else:
             raise Exception("Iperf multiple attempts failed: %s" % fail_data)
 
         res = {'info': 'Test ran successfully',
-                'data': iperf_data,
-                'config': self.IPERF_ARGS }
+               'data': iperf_data,
+               'config': self.IPERF_ARGS}
         if fail_data:
             res.update({'warning': fail_data})
         return res
@@ -742,20 +754,23 @@ class PIFParamTestClass(IperfTestClass):
         for k, v in self.OFFLOAD_CONFIG.iteritems():
             if k not in hw_offloads:
                 raise Exception("Cannot determine status of %s." % k)
-            log.debug("Device: %s (%s offload: %s)" % (device, k, hw_offloads[k]))
+            log.debug("Device: %s (%s offload: %s)" %
+                      (device, k, hw_offloads[k]))
             if not hw_offloads[k].startswith(v):
                 # Newest ethtool will tell whether the offload setting can be changed.
                 # If it is not possible due to the hardware ristriction, then ACK should
                 # ignore this failure and keep running tests.
                 if '[fixed]' in hw_offloads[k]:
-                    log.debug("Required offload %s is fixed to %s." % (k, hw_offloads[k]))
+                    log.debug("Required offload %s is fixed to %s." %
+                              (k, hw_offloads[k]))
                 else:
-                    raise Exception("%s offload was not in the correct state (is %s)" % (k, hw_offloads[k]))
-                                
+                    raise Exception(
+                        "%s offload was not in the correct state (is %s)" % (k, hw_offloads[k]))
+
     def _setup_pif_params(self, session, network_ref):
         pifs = session.xenapi.network.get_PIFs(network_ref)
         log.debug("PIFs retrieved %s" % pifs)
-        #Set argument on PIF
+        # Set argument on PIF
         for pif in pifs:
             self._set_offload_params(session, pif)
             device = session.xenapi.PIF.get_device(pif)
@@ -768,10 +783,10 @@ class PIFParamTestClass(IperfTestClass):
         management_network_ref = get_management_network(session)
 
         for network_ref in network_refs:
-    
+
             # Don't configure PIF params for the management NIC
             if network_ref != management_network_ref:
-                #Setup Pif Params
+                # Setup Pif Params
                 self._setup_pif_params(session, network_ref)
 
         return network_refs
@@ -782,11 +797,12 @@ class PIFParamTestClass(IperfTestClass):
 class Dom0VMIperfTestClass(PIFParamTestClass):
     """A subclass of the PIFParamTest class, this
     class runs the tests between Dom0 and a VM,
-    rather than just between VMs"""    
+    rather than just between VMs"""
 
     mode = "dom0-vm"
     IPERF_ARGS = {'format': 'm',
                   'thread_count': '1'}
+
 
 class Dom0VMBridgeIperfTestClass(Dom0VMIperfTestClass):
     """Subclass that runs the appropriate tests with bridge as the default backend."""
@@ -801,6 +817,7 @@ class Dom0PIFParamTestClass1(PIFParamTestClass):
 
     mode = "dom0-dom0"
 
+
 class Dom0PIFParamTestClass2(Dom0PIFParamTestClass1):
     """A class for Dom0 - VM PIF param testing"""
 
@@ -813,6 +830,7 @@ class Dom0PIFParamTestClass2(Dom0PIFParamTestClass1):
                       'lro': 'off',
                       'rxvlan': 'on',
                       'txvlan': 'on'}
+
 
 class Dom0PIFParamTestClass3(Dom0PIFParamTestClass1):
     """A class for Dom0 - VM PIF param testing"""
@@ -829,16 +847,18 @@ class Dom0PIFParamTestClass3(Dom0PIFParamTestClass1):
 
 ########## Dom0 to Dom0 *Bridge* PIF parameter test classes #########
 
+
 class Dom0BridgePIFParamTestClass1(PIFParamTestClass):
     """A class for Dom0 - VM PIF param testing"""
-    
+
     network_backend = "bridge"
     mode = "dom0-dom0"
     order = 5
 
+
 class Dom0BridgePIFParamTestClass2(Dom0BridgePIFParamTestClass1):
     """A class for Dom0 - VM PIF param testing"""
- 
+
     caps = []
     required = False
     OFFLOAD_CONFIG = {'sg': 'on',
@@ -849,9 +869,10 @@ class Dom0BridgePIFParamTestClass2(Dom0BridgePIFParamTestClass1):
                       'rxvlan': 'on',
                       'txvlan': 'on'}
 
+
 class Dom0BridgePIFParamTestClass3(Dom0BridgePIFParamTestClass1):
     """A class for Dom0 - VM PIF param testing"""
-    
+
     caps = []
     required = False
     OFFLOAD_CONFIG = {'sg': 'on',
@@ -863,22 +884,23 @@ class Dom0BridgePIFParamTestClass3(Dom0BridgePIFParamTestClass1):
                       'txvlan': 'on'}
 
 ########## Jumbo Frames (Large MTU) Test Classes ###########
-    
+
+
 class MTUPingTestClass(testbase.NetworkTestClass):
     """A test class for ensuring that hardware can cope with 
     transmitting large MTU.  Note, this test case is only 
     compatible with the open vswitch backend"""
-    
+
     MTU = '9000'
-    
+
     PING_ARGS = {'packet_size': 8000,
                  'packet_count': 20}
-    
+
     username = 'root'
     password = DEFAULT_PASSWORD
 
     num_ips_required = 2
-    
+
     def _setup_network(self, session):
         """Utility method for setting the network MTU and 
         returning the network reference to be used by VMs"""
@@ -900,18 +922,18 @@ class MTUPingTestClass(testbase.NetworkTestClass):
             sms[net_ref] = self.get_static_manager(net_ref)
 
         return deploy_two_droid_vms(session, net_refs, sms)
-    
+
     def _run_test(self, session):
         """Runs a ping test using a set MTU and the -M switch,
         for MTU discovery, to verify successful packet delivery to VM2"""
-        
-        #setup required network
+
+        # setup required network
         net_refs = self._setup_network(session)
-        
-        #setup VMs for test
+
+        # setup VMs for test
         vm1_ref, vm2_ref = self._setup_vms(session, net_refs)
-        
-        #retrieve VM IPs
+
+        # retrieve VM IPs
         vm1_ip = wait_for_ip(session, vm1_ref, 'eth0')
         log.debug("VM %s has IP %s (iface: eth0)" % (vm1_ref, vm1_ip))
 
@@ -924,39 +946,36 @@ class MTUPingTestClass(testbase.NetworkTestClass):
         vm2_ip_eth1 = wait_for_ip(session, vm2_ref, 'eth1')
         log.debug("VM %s has IP %s (iface: eth1)" % (vm2_ref, vm2_ip_eth1))
 
-
         # Add explicit IP routes to ensure MTU traffic travels
         # across the correct interface.
 
         args = {
-                'vm_ref': vm1_ref,
-                'dest_ip': vm2_ip_eth1,
-                'dest_mac': get_vm_device_mac(session, vm2_ref, 'eth1'),
-                'device': 'eth1',
-               }   
-        
+            'vm_ref': vm1_ref,
+            'dest_ip': vm2_ip_eth1,
+            'dest_mac': get_vm_device_mac(session, vm2_ref, 'eth1'),
+            'device': 'eth1',
+        }
+
         call_ack_plugin(session, 'add_route', args)
 
         args = {
-                'vm_ref': vm2_ref,
-                'dest_ip': vm1_ip_eth1,
-                'dest_mac': get_vm_device_mac(session, vm1_ref, 'eth1'),
-                'device': 'eth1',
-               }   
-        
+            'vm_ref': vm2_ref,
+            'dest_ip': vm1_ip_eth1,
+            'dest_mac': get_vm_device_mac(session, vm1_ref, 'eth1'),
+            'device': 'eth1',
+        }
+
         call_ack_plugin(session, 'add_route', args)
-
-
 
         for vm_ref in [vm1_ref, vm2_ref]:
             check_vm_ping_response(session, vm_ref)
 
         ips = [vm1_ip, vm2_ip]
-        #SSH to vm 'ifconfig ethX mtu XXXX up'
+        # SSH to vm 'ifconfig ethX mtu XXXX up'
         cmd_str = 'ifconfig eth1 mtu %s up' % self.MTU
         for vm_ip in ips:
             ssh_command(vm_ip, self.username, self.password, cmd_str)
-        
+
         log.debug("Starting large MTU ping test...")
 
         log.debug("Attempt normal ping first...")
@@ -964,23 +983,22 @@ class MTUPingTestClass(testbase.NetworkTestClass):
 
         log.debug("Moving onto large MTU ping...")
         log.debug("Ping Arguments: %s" % self.PING_ARGS)
-        #set ping args and run cmd
-        ping_result = ping(vm1_ip, vm2_ip_eth1, 'eth1', self.PING_ARGS['packet_size'], self.PING_ARGS['packet_count'])
+        # set ping args and run cmd
+        ping_result = ping(vm1_ip, vm2_ip_eth1, 'eth1', self.PING_ARGS[
+                           'packet_size'], self.PING_ARGS['packet_count'])
         log.debug("Result: %s" % ping_result)
-            
-            
+
         rec = {}
         rec['data'] = ping_result
         rec['config'] = self.PING_ARGS
-            
-        #Check for failure
+
+        # Check for failure
         if "0% packet loss" not in ping_result:
-            raise TestCaseError("Error: Large MTU ping transmission failed. %s" 
+            raise TestCaseError("Error: Large MTU ping transmission failed. %s"
                                 % ping_result)
-    
+
         return rec
-    
-        
+
     def test_ping(self, session):
         log.debug("run test...")
         return self._run_test(session)
@@ -994,7 +1012,7 @@ class GROOffloadTestClass(testbase.NetworkTestClass):
         net_ref = self.get_networks()[0]
         pifs = session.xenapi.network.get_PIFs(net_ref)
         log.debug("PIFs to test: %s" % pifs)
-        #Set argument on PIF
+        # Set argument on PIF
         for pif in pifs:
             device = session.xenapi.PIF.get_device(pif)
             set_hw_offload(session, device, 'gro', 'on')
@@ -1010,4 +1028,3 @@ class GROOffloadBridgeTestClass(GROOffloadTestClass):
     GRO is on by default from XS 6.5 """
     network_backend = "bridge"
     order = 5
-    

--- a/autocertkit/operations_tests.py
+++ b/autocertkit/operations_tests.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 import testbase
@@ -34,195 +34,204 @@ from utils import *
 
 log = get_logger('auto-cert-kit')
 
+
 class VMOpsTestClass(testbase.OperationsTestClass):
     """Test class to determine proper operation of the most
     basic VM procedures"""
-    
-    #Deine the number of test VMs
+
+    # Deine the number of test VMs
     vm_count = 3
-    
+
     def _setup_vms(self, session):
         """Creates vm_count VMs on the 
         master host's local SR"""
         host_ref = get_pool_master(session)
         net_ref = get_management_network(session)
         return deploy_count_droid_vms_on_host(session,
-                                              host_ref, 
+                                              host_ref,
                                               [net_ref],
                                               self.vm_count,
                                               {net_ref: self.get_static_manager(net_ref)})
-        
+
     def test_vm_power_control(self, session):
         """Creates a number of VMs and alterates the power
         state a predefined number of times"""
         vm_ref_list = self._setup_vms(session)
         for i in range(3):
-            log.debug("Starting test run %d of %d" % (i+1, range(3)[-1]+1))
+            log.debug("Starting test run %d of %d" % (i + 1, range(3)[-1] + 1))
 
-            #Make certain the VMs are available
+            # Make certain the VMs are available
             for vm_ref in vm_ref_list:
                 check_vm_ping_response(session, vm_ref)
 
-            #Shut down all VMs
+            # Shut down all VMs
             log.debug("Shutting down VMs: %s" % vm_ref_list)
             """Note that it is required we build the following 'task_list' 
             in this manner, i.e 'x=vm_ref', so that we can get around a 
             particular issue with Python variable bindings within loops"""
-            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.clean_shutdown(x)) 
+            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.clean_shutdown(x))
                          for vm_ref in vm_ref_list]
             res = run_xapi_async_tasks(session, task_list)
-    
-            #Verify the VMs report a 'Halted' power state
+
+            # Verify the VMs report a 'Halted' power state
             log.debug("Verrifying VM power control operations")
             for vm_ref in vm_ref_list:
                 if session.xenapi.VM.get_power_state(vm_ref) != 'Halted':
-                    raise Exception("ERROR: Unexpected power state; VM did not shut down")
+                    raise Exception(
+                        "ERROR: Unexpected power state; VM did not shut down")
                 log.debug("VM %s is shut down" % vm_ref)
             log.debug("Verrification complete: All VMs have shut down")
-                    
-            #Boot all VMs
+
+            # Boot all VMs
             log.debug("Booting VMs: %s" % vm_ref_list)
             host_ref = get_pool_master(session)
-            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.start_on(x, 
-                                                                            host_ref, 
-                                                                            False, 
-                                                                            False)) 
+            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.start_on(x,
+                                                                            host_ref,
+                                                                            False,
+                                                                            False))
                          for vm_ref in vm_ref_list]
             res = run_xapi_async_tasks(session, task_list)
-             
-            #Verify the VMs report a 'Running' power state
+
+            # Verify the VMs report a 'Running' power state
             log.debug("Verrifying VM power control operations")
             for vm_ref in vm_ref_list:
                 if session.xenapi.VM.get_power_state(vm_ref) != 'Running':
-                    raise Exception("ERROR: Unexpected power state; VM did not boot")
+                    raise Exception(
+                        "ERROR: Unexpected power state; VM did not boot")
                 log.debug("VM %s is running" % vm_ref)
             log.debug("Verrification complete: All VMs have booted")
-            
-            log.debug("Test run %d of %d has completed successfully" % (i+1, range(3)[-1]+1)) 
-            
+
+            log.debug("Test run %d of %d has completed successfully" %
+                      (i + 1, range(3)[-1] + 1))
+
         rec = {}
         rec['info'] = ("VM power state tests completed successfully.")
-        
+
         return rec
-                
+
     def test_vm_reboot(self, session):
         """Creates a number of VMs and continuously reboots
         them a predefined number of times"""
         vm_ref_list = self._setup_vms(session)
         for i in range(3):
-            log.debug("Starting test run %d of %d" % (i+1, range(3)[-1]+1))
-            
-            #Make certain the VMs are available
+            log.debug("Starting test run %d of %d" % (i + 1, range(3)[-1] + 1))
+
+            # Make certain the VMs are available
             for vm_ref in vm_ref_list:
                 check_vm_ping_response(session, vm_ref)
-            
-            #Reboot all VMs
+
+            # Reboot all VMs
             log.debug("Rebooting VMs: %s" % vm_ref_list)
-            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.clean_reboot(x)) 
+            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.clean_reboot(x))
                          for vm_ref in vm_ref_list]
             res = run_xapi_async_tasks(session, task_list)
-            
-            #Verify the VMs report a 'Running' power state
+
+            # Verify the VMs report a 'Running' power state
             log.debug("Verrifying VM power control operations")
             for vm_ref in vm_ref_list:
                 if session.xenapi.VM.get_power_state(vm_ref) != 'Running':
                     raise Exception("ERROR: Unexpected power state")
                 log.debug("VM %s is running" % vm_ref)
             log.debug("Verrification complete: All VMs have rebooted")
-            
-            log.debug("Test run %d of %d has completed successfully" % (i+1, range(3)[-1]+1)) 
-            
+
+            log.debug("Test run %d of %d has completed successfully" %
+                      (i + 1, range(3)[-1] + 1))
+
         rec = {}
         rec['info'] = ("VM reboot test completed successfully")
-        
+
         return rec
-    
+
     def test_vm_suspend(self, session):
         """Creates a number of VMs and verifies correct
         suspend/resume functionality through three test runs"""
         vm_ref_list = self._setup_vms(session)
         for i in range(3):
-            log.debug("Starting test run %d of %d" % (i+1, range(3)[-1]+1)) 
-            
-            #Make certain the VMs are available
+            log.debug("Starting test run %d of %d" % (i + 1, range(3)[-1] + 1))
+
+            # Make certain the VMs are available
             for vm_ref in vm_ref_list:
                 check_vm_ping_response(session, vm_ref)
-            
-            #Suspend all VMs
+
+            # Suspend all VMs
             log.debug("Suspending VMs: %s" % vm_ref_list)
-            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.suspend(x)) 
+            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.suspend(x))
                          for vm_ref in vm_ref_list]
             start = time.time()
             res = run_xapi_async_tasks(session, task_list, 1200)
             suspend_time = time.time() - start
-            log.debug("Suspend operation returned complete in %s seconds" % suspend_time)
-            
-            #Verify the VMs report a 'Suspended' power state
+            log.debug(
+                "Suspend operation returned complete in %s seconds" % suspend_time)
+
+            # Verify the VMs report a 'Suspended' power state
             log.debug("Verrifying VM power control operations")
             for vm_ref in vm_ref_list:
                 if session.xenapi.VM.get_power_state(vm_ref) != 'Suspended':
                     raise Exception("ERROR: VM %s did not suspend" % vm_ref)
                 log.debug("VM %s is suspended" % vm_ref)
             log.debug("Verrification complete: All VMs have been suspended")
-            
-            #Resume all VMs
+
+            # Resume all VMs
             log.debug("Resuming VMs: %s" % vm_ref_list)
             host_ref = get_pool_master(session)
-            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.resume_on(x, 
-                                                                             host_ref, 
-                                                                             False, 
-                                                                             False)) 
+            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.resume_on(x,
+                                                                             host_ref,
+                                                                             False,
+                                                                             False))
                          for vm_ref in vm_ref_list]
             res = run_xapi_async_tasks(session, task_list)
-            
-            #Verify the VMs report a 'Running' power state
+
+            # Verify the VMs report a 'Running' power state
             log.debug("Verrifying VM power control operations")
             for vm_ref in vm_ref_list:
                 if session.xenapi.VM.get_power_state(vm_ref) != 'Running':
                     raise Exception("ERROR: VM %s did not resume" % vm_ref)
-                log.debug("VM %s is running" % vm_ref) 
+                log.debug("VM %s is running" % vm_ref)
             log.debug("Verrification complete: All VMs have resumed")
-            
-            log.debug("Test run %d of %d has completed successfully" % (i+1, range(3)[-1]+1)) 
-            
+
+            log.debug("Test run %d of %d has completed successfully" %
+                      (i + 1, range(3)[-1] + 1))
+
         rec = {}
         rec['info'] = ("VM suspend tests completed successfully")
-       
+
         return rec
-    
-    def test_vm_relocation(self, session):      
+
+    def test_vm_relocation(self, session):
         """Creates a number of VMs and 'relocates' them between
         the master host and the master host"""
-        vm_ref_list = self._setup_vms(session)         
+        vm_ref_list = self._setup_vms(session)
         for i in range(3):
-            log.debug("Starting test run %d of %d" % (i+1, range(3)[-1]+1))
-            
-            #Make certain the VMs are available
+            log.debug("Starting test run %d of %d" % (i + 1, range(3)[-1] + 1))
+
+            # Make certain the VMs are available
             for vm_ref in vm_ref_list:
                 check_vm_ping_response(session, vm_ref)
-            
-            #Relocate all VMs
+
+            # Relocate all VMs
             log.debug("Relocating VMs: %s" % vm_ref_list)
             host_ref = get_pool_master(session)
-            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.pool_migrate(x, 
-                                                                                host_ref, 
-                                                                                {'live': 'true'})) 
+            task_list = [(lambda x=vm_ref: session.xenapi.Async.VM.pool_migrate(x,
+                                                                                host_ref,
+                                                                                {'live': 'true'}))
                          for vm_ref in vm_ref_list]
             res = run_xapi_async_tasks(session, task_list)
-             
-            #Verify the VMs report a 'Running' power state
+
+            # Verify the VMs report a 'Running' power state
             log.debug("Verrifying VM power control operations")
             for vm_ref in vm_ref_list:
                 if session.xenapi.VM.get_power_state(vm_ref) != 'Running':
                     raise Exception("ERROR: Unexpected power state")
                 log.debug("VM %s is running" % vm_ref)
-            log.debug("Verrification complete: All VMs have been relocated and are running")
-            
-            log.debug("Test run %d of %d has completed successfully" % (i+1, range(3)[-1]+1)) 
-                
+            log.debug(
+                "Verrification complete: All VMs have been relocated and are running")
+
+            log.debug("Test run %d of %d has completed successfully" %
+                      (i + 1, range(3)[-1] + 1))
+
         rec = {}
         rec['info'] = ("VM relocation tests completed successfully")
-        
+
         return rec
 
 
@@ -235,30 +244,37 @@ class CrashDumpTestClass(testbase.OperationsTestClass):
         if not get_reboot_flag():
             tc_info = {}
             tc_info['device'] = self.config['device_config']['udid']
-            tc_info['test_class'] = self.__class__.__module__ + '.' + self.__class__.__name__
+            tc_info['test_class'] = self.__class__.__module__ + \
+                '.' + self.__class__.__name__
             tc_info['test_method'] = 'test_crashdump'
-            tc_info['crash_begin_time'] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            tc_info['crash_begin_time'] = datetime.now(
+            ).strftime("%Y-%m-%d %H:%M:%S")
             set_reboot_flag(tc_info)
-            log.debug("The reboot flag's timestamp is set to: '%s'" % str(get_reboot_flag_timestamp()))
-            time.sleep(5) # host crash need to be done after flag is created to compare.
+            log.debug("The reboot flag's timestamp is set to: '%s'" %
+                      str(get_reboot_flag_timestamp()))
+            # host crash need to be done after flag is created to compare.
+            time.sleep(5)
             host_crash(self.session)
-        
+
         # Check tc_info is persistent.
         tc_info = get_reboot_flag()
         log.debug("tc_info from reboot flag: %s" % str(tc_info))
         if 'crash_begin_time' not in tc_info:
-            raise Exception("Reboot flag is not persistent and does not include crash info. Does host restarted by forced crashdump?")
-        crash_beg_time = datetime(*(time.strptime(tc_info['crash_begin_time'],"%Y-%m-%d %H:%M:%S")[0:6]))
+            raise Exception(
+                "Reboot flag is not persistent and does not include crash info. Does host restarted by forced crashdump?")
+        crash_beg_time = datetime(
+            *(time.strptime(tc_info['crash_begin_time'], "%Y-%m-%d %H:%M:%S")[0:6]))
         log.debug("host crashed at %s" % str(crash_beg_time))
 
         # Check new crashdump was created during host crash.
         crashdumps_all = retrieve_crashdumps(session)
         log.debug("available crashdumps: %s" % (str(crashdumps_all)))
-        crashdumps_matching = [cd for cd in crashdumps_all if crash_beg_time < cd['timestamp']]
+        crashdumps_matching = [
+            cd for cd in crashdumps_all if crash_beg_time < cd['timestamp']]
         log.debug("matched crashdump(s): %s" % (str(crashdumps_matching)))
         if not len(crashdumps_matching) == 1:
-            raise Exception("Host didn't create crashdump properly. number of new crashdumps: %d" % len(crashdumps_matching))
+            raise Exception("Host didn't create crashdump properly. number of new crashdumps: %d" % len(
+                crashdumps_matching))
 
         res = {'info': "An additional crashdump was detected."}
         return res
-

--- a/autocertkit/status.py
+++ b/autocertkit/status.py
@@ -3,31 +3,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """Module for checking the status of the kit. This will be of most interest
@@ -43,41 +43,47 @@ TEST_FILE = "test_run.conf"
 DEFAULT_RUN_LEVEL = 3
 running = False
 
+
 def get_process_strings():
-    ps = subprocess.Popen(['ps', 'aux'], stdout=subprocess.PIPE).communicate()[0]
+    ps = subprocess.Popen(
+        ['ps', 'aux'], stdout=subprocess.PIPE).communicate()[0]
     process_strings = []
     for line in ps.split('\n'):
         if 'ack_cli.py' in line or 'test_runner.py' in line:
             process_strings.append(line)
     return process_strings
 
+
 def check_for_process():
     process_strings = get_process_strings()
-    my_pid = str(os.getpid())    
+    my_pid = str(os.getpid())
     for line in process_strings:
         if my_pid in line:
             process_strings.remove(line)
     if process_strings:
         return True
 
+
 def get_run_level():
-    output = subprocess.Popen(['/sbin/runlevel'], stdout=subprocess.PIPE).communicate()[0]
+    output = subprocess.Popen(
+        ['/sbin/runlevel'], stdout=subprocess.PIPE).communicate()[0]
     _, level = output.split()
     return int(level)
+
 
 def main():
     running = False
 
-    #Check for manifest file
+    # Check for manifest file
     if not os.path.exists(TEST_FILE):
         print "4:Manifest file has not been created. Have run the kit? (Has an error occured?)"
         sys.exit(0)
 
-    #Check for the python process
+    # Check for the python process
     if check_for_process():
         running = True
 
-    #Check the XML file to find out how many tests have been run
+    # Check the XML file to find out how many tests have been run
     try:
         ack_run = models.parse_xml(TEST_FILE)
     except:
@@ -87,15 +93,15 @@ def main():
     p, f, s, w = ack_run.get_status()
 
     if w == 0:
-        print "0:Finished (Passed:%d, Failed:%d, Skipped:%d)" % (p,f,s)
+        print "0:Finished (Passed:%d, Failed:%d, Skipped:%d)" % (p, f, s)
     elif not running and utils.get_reboot_flag():
-        print "3:Server rebooting... (Passed:%d, Failed:%d, Skipped:%d, Waiting:%d)" % (p,f,s,w)
+        print "3:Server rebooting... (Passed:%d, Failed:%d, Skipped:%d, Waiting:%d)" % (p, f, s, w)
     elif not running and not utils.get_reboot_flag():
-        print "1:Process not running. An error has occurred. (Passed:%d, Failed:%d, Skipped: %d, Waiting:%d)" % (p,f,s,w)
+        print "1:Process not running. An error has occurred. (Passed:%d, Failed:%d, Skipped: %d, Waiting:%d)" % (p, f, s, w)
         sys.exit(1)
     else:
-        perc = float(p + f + s)/float(w + p + f + s) * 100
-        print "2:Running - %d%% Complete (Passed:%d, Failed:%d, Skipped:%d, Waiting:%d)" % (perc,p,f,s,w)
+        perc = float(p + f + s) / float(w + p + f + s) * 100
+        print "2:Running - %d%% Complete (Passed:%d, Failed:%d, Skipped:%d, Waiting:%d)" % (perc, p, f, s, w)
 
 if __name__ == "__main__":
     main()

--- a/autocertkit/storage_tests.py
+++ b/autocertkit/storage_tests.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """A module for storage specific test cases"""
@@ -35,23 +35,24 @@ from utils import *
 
 log = get_logger('auto-cert-kit')
 
+
 class PerfTestClass(testbase.LocalStorageTestClass):
     """A somewhat generic test class for local storage 
     performance tests that could be expanded to include 
     additional plugin-based tasks"""
-    
-    #Deine the test timeout in seconds and the number of test VMs
+
+    # Deine the test timeout in seconds and the number of test VMs
     timeout = 3600
     vm_count = 3
-    
-    #SSH command variables
+
+    # SSH command variables
     username = 'root'
     password = DEFAULT_PASSWORD
-    
-    #Class variables
+
+    # Class variables
     test = ''
     cmd_str = ''
-    
+
     def _setup_vms(self, session):
         """Creates vm_count VMs on the 
         master host's local SR"""
@@ -64,13 +65,14 @@ class PerfTestClass(testbase.LocalStorageTestClass):
             log.debug("Choosing first local SR.")
             sr_ref = get_local_sr(session, host_ref)
         log.debug("%s is chosen for local storage test." % sr_ref)
-        return deploy_count_droid_vms_on_host(session, 
-                                              host_ref, 
-                                              [net_ref], 
+        return deploy_count_droid_vms_on_host(session,
+                                              host_ref,
+                                              [net_ref],
                                               self.vm_count,
-                                              {net_ref: self.get_static_manager(net_ref)},
+                                              {net_ref: self.get_static_manager(
+                                                  net_ref)},
                                               sr_ref)
-        
+
     def _call_plugin(self, session, vm_ref_list, call):
         """Util function to call ACK plugin method"""
         res = []
@@ -81,11 +83,11 @@ class PerfTestClass(testbase.LocalStorageTestClass):
                                         'password': self.password}))
         return res
 
-    def _create_test_threads(self, session, vm_ref_list):    
+    def _create_test_threads(self, session, vm_ref_list):
         """Spawns a new test thread using the cmd_strin a 
         timeout function over SSH to every VM in vm_ref_list"""
         threads = []
-        for vm_ref in vm_ref_list:    
+        for vm_ref in vm_ref_list:
             vm_ip = wait_for_ip(session, vm_ref, 'eth0')
             threads.append(create_test_thread(lambda: TimeoutFunction(ssh_command(vm_ip,
                                                                                   self.username,
@@ -93,37 +95,38 @@ class PerfTestClass(testbase.LocalStorageTestClass):
                                                                                   self.cmd_str),
                                                                       self.timeout, '%s test timed out %d' % (self.test, self.timeout))))
         return threads
-        
+
     def _run_test(self, session):
         """Run test function"""
-        #setup vms
+        # setup vms
         vm_ref_list = self._setup_vms(session)
-        
-        #Make certain the VMs are available
+
+        # Make certain the VMs are available
         for vm_ref in vm_ref_list:
             check_vm_ping_response(session, vm_ref)
-                
-        #deploy test rpms
+
+        # deploy test rpms
         self._call_plugin(session, vm_ref_list, 'deploy_' + self.test)
-        
-        #create, start test threads, wait until complete
+
+        # create, start test threads, wait until complete
         log.debug("About to run %s test..." % self.test)
         threads = self._create_test_threads(session, vm_ref_list)
-        
-        #Wait for the threads to finish running or timeout
+
+        # Wait for the threads to finish running or timeout
         start = time.time()
-        while check_test_thread_status(threads): 
+        while check_test_thread_status(threads):
             time.sleep(1)
             if should_timeout(start, self.timeout):
-                raise Exception("%s test timed out %s" % (self.test, self.timeout))
-        
-        #retrieve the logs
+                raise Exception("%s test timed out %s" %
+                                (self.test, self.timeout))
+
+        # retrieve the logs
         log.debug("%s test is complete, retrieving logs" % self.test)
-        res = self._call_plugin(session, vm_ref_list, 'retrieve_' + self.test + '_logs')
+        res = self._call_plugin(session, vm_ref_list,
+                                'retrieve_' + self.test + '_logs')
 
         return {'info': 'Test ran successfully'}
-    
-    
+
     def test_iozone(self, session):
         """Perform the IOZone Local Storage benchmark"""
         self.test = 'iozone'
@@ -137,11 +140,13 @@ class PerfTestClass(testbase.LocalStorageTestClass):
                   'count': '1',
                   'user': 'citrix',
                   'log': '2>&1 | tee /root/localhost.log'}
-        
+
         self.test = 'bonnie'
         self.cmd_str = 'bonnie++ -d %s -s %s -x %s -u %s %s' % (config['scratch_dir'],
-                                                                config['file_size'],
-                                                                config['count'],
+                                                                config[
+                                                                    'file_size'],
+                                                                config[
+                                                                    'count'],
                                                                 config['user'],
                                                                 config['log'])
         return self._run_test(session)

--- a/autocertkit/test_generators.py
+++ b/autocertkit/test_generators.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """Python module for generating the list of tests specific to each device"""
@@ -41,6 +41,7 @@ import storage_tests
 import operations_tests
 import testbase
 from xml.dom import minidom
+
 
 class TestGenerator(object):
     """Test class for enumerating test config and information. The class
@@ -60,7 +61,7 @@ class TestGenerator(object):
         self.session = session
         self.config = config
         self.interface = interface
-        #if not self.TAG:
+        # if not self.TAG:
         #    raise Exception("The TestGenerator class is generic. Please inherit for a specific device")
         self.prereq_check()
 
@@ -82,17 +83,19 @@ class TestGenerator(object):
         for test_module in utils.get_module_names('_tests'):
             test_classes = inspect.getmembers(sys.modules[test_module],
                                               inspect.isclass)
-            #utils.log.debug(test_classes)
+            # utils.log.debug(test_classes)
             for test_name, test_class in test_classes:
-                #Check that the class is subclassed from the base TestClass
+                # Check that the class is subclassed from the base TestClass
                 if issubclass(test_class, testbase.TestClass):
                     # If a tag exists, then we should make sure that the classes tags list
                     # contains the specified tag. If not, then we will add the test to be run
                     # anyway.
-                    if self.TAG and (not self.TAG in test_class(self.session,self.config).tags):
+                    if self.TAG and (not self.TAG in test_class(self.session, self.config).tags):
                         continue
-                    test_classes_to_run.append(("%s.%s" % (test_module, test_name), test_class))
-        #Return the tuple (test_class_name, test_class) where the test_class value is a class object
+                    test_classes_to_run.append(
+                        ("%s.%s" % (test_module, test_name), test_class))
+        # Return the tuple (test_class_name, test_class) where the test_class
+        # value is a class object
         return self.filter_test_classes(test_classes_to_run)
 
     def get_uid(self):
@@ -153,38 +156,41 @@ class TestGenerator(object):
 
             class_node = doc.createElement('test_class')
             class_node.setAttribute('name', test_class_name)
-            class_node.setAttribute('caps', str(test_class(self.session,self.config).caps))
-            class_node.setAttribute('order', str(test_class(self.session,self.config).order))
+            class_node.setAttribute('caps', str(
+                test_class(self.session, self.config).caps))
+            class_node.setAttribute('order', str(
+                test_class(self.session, self.config).order))
 
             test_methods = test_class(self.session, self.config).list_tests()
             for method in test_methods:
                 method_node = doc.createElement('test_method')
                 method_node.setAttribute('name', str(method))
 
-                #Result/Info fields
+                # Result/Info fields
                 result_node = doc.createElement('result')
                 info_node = doc.createElement('info')
                 if skipthis:
                     result_node.appendChild(doc.createTextNode('skip'))
                     reason_node = doc.createElement('reason')
                     reason_node.appendChild(doc.createTextNode('%s is not required for XCP %s.'
-                                            % (test_class_name, xcp_version)))
+                                                               % (test_class_name, xcp_version)))
                     method_node.appendChild(reason_node)
                 else:
                     result_node.appendChild(doc.createTextNode('NULL'))
-                
+
                 method_node.appendChild(result_node)
                 method_node.appendChild(info_node)
                 testname_node = doc.createElement('test_name')
                 testname_node.appendChild(doc.createTextNode('%s.%s' %
-                    (test_class_name.split('.')[1], str(method))))
+                                                             (test_class_name.split('.')[1], str(method))))
                 method_node.appendChild(testname_node)
 
                 class_node.appendChild(method_node)
 
             cts_node.appendChild(class_node)
-            
+
         xml_node.appendChild(device_node)
+
 
 class NetworkAdapterTestGenerator(TestGenerator):
     """TestGenerator class specific for NA tests"""
@@ -199,12 +205,14 @@ class NetworkAdapterTestGenerator(TestGenerator):
             # which are going to be run.
             min_ips_required = 0
             for test_name, test_class in self.get_test_classes():
-                class_ips = test_class(self.session, self.config).num_ips_required
+                class_ips = test_class(
+                    self.session, self.config).num_ips_required
                 if class_ips > min_ips_required:
                     min_ips_required = class_ips
-                             
+
             if min_ips_required > num_ips_provided:
-                raise Exception("For these tests, at least %d static IPs must be provided. You provided only %d" % (min_ips_required, num_ips_provided))
+                raise Exception("For these tests, at least %d static IPs must be provided. You provided only %d" % (
+                    min_ips_required, num_ips_provided))
 
     def filter_test_classes(self, test_classes):
         utils.log.debug("Config Keys: %s" % self.config.keys())
@@ -218,20 +226,21 @@ class NetworkAdapterTestGenerator(TestGenerator):
             return True
 
         if 'OVS' in self.config['exclude']:
-            test_classes = [(testname, testclass) for testname, testclass 
-                    in test_classes if not testclass.network_backend or
-                    testclass.network_backend == 'bridge']
+            test_classes = [(testname, testclass) for testname, testclass
+                            in test_classes if not testclass.network_backend or
+                            testclass.network_backend == 'bridge']
         if 'BRIDGE' in self.config['exclude']:
-            test_classes = [(testname, testclass) for testname, testclass 
-                    in test_classes if not testclass.network_backend or
-                    testclass.network_backend == 'vswitch']
+            test_classes = [(testname, testclass) for testname, testclass
+                            in test_classes if not testclass.network_backend or
+                            testclass.network_backend == 'vswitch']
 
         if 'singlenic' in self.config.keys() and self.config['singlenic'] == "true":
             dont_run = ["BondingTestClass", "MTUPingTestClass"]
-            return [(testname, testclass) for testname, testclass 
+            return [(testname, testclass) for testname, testclass
                     in test_classes if append_filter(testname, dont_run)]
         else:
             return test_classes
+
 
 class ProcessorTestGenerator(TestGenerator):
     """TestGenertor class specific to Processor tests"""
@@ -249,10 +258,11 @@ class ProcessorTestGenerator(TestGenerator):
         cpu_rec = self.session.xenapi.host.get_cpu_info(master_ref)
         return utils.combine_recs(rec, cpu_rec)
 
+
 class StorageTestGenerator(TestGenerator):
     """TestGenertor class specific to Storage tests"""
     TAG = 'LS'
-    
+
     def __init__(self, session, config, device):
         super(StorageTestGenerator, self).__init__(session, config)
         self.device = device
@@ -267,16 +277,17 @@ class StorageTestGenerator(TestGenerator):
         rec = super(StorageTestGenerator, self).get_device_config()
         return utils.combine_recs(rec, self.device)
 
+
 class OperationsTestGenerator(TestGenerator):
     """TestGenertor class specific to Operations tests"""
     TAG = 'OP'
-    
+
     def filter_test_classes(self, test_classes):
         if 'OPS' in self.config['exclude']:
             return []
         if 'CRASH' in self.config['exclude']:
             test_classes = [(testname, testclass) for testname, testclass
-                    in test_classes if 'CrashDump' not in testname]
+                            in test_classes if 'CrashDump' not in testname]
         return test_classes
 
     def get_device_config(self):
@@ -287,6 +298,7 @@ class OperationsTestGenerator(TestGenerator):
         return rec
 
 ##############################################################################
+
 
 class DeviceXMLGenerator(object):
 
@@ -311,13 +323,15 @@ class DeviceXMLGenerator(object):
         gen = self.CLS(self.session, self.config)
         gen.append_xml_config(doc, devices_node)
 
+
 class NetworkAdaptersXMLGenerator(DeviceXMLGenerator):
 
     TAGS = ["NET"]
 
     def _append_xml_config(self, doc, devices_node):
         for iface in self.network_ifs:
-            natg = NetworkAdapterTestGenerator(self.session, self.config, iface)
+            natg = NetworkAdapterTestGenerator(
+                self.session, self.config, iface)
             natg.append_xml_config(doc, devices_node)
 
 
@@ -335,6 +349,7 @@ class ProcessorsXMLGenerator(DeviceXMLGenerator):
 
     TAGS = ["CPU"]
     CLS = ProcessorTestGenerator
+
 
 class OperationsXMLGenerator(DeviceXMLGenerator):
 
@@ -359,7 +374,7 @@ def print_documentation(object_name):
     for test_class_name, test_class in classes:
         arr = (object_name).split('.')
         if test_class_name == object_name:
-            #get the class info
+            # get the class info
             print "%s: %s" % (utils.bold('Prereqs'), test_class.required_config)
             print "%s: %s" % (utils.bold('Collects'), test_class.collects)
             print ""
@@ -372,7 +387,7 @@ def print_documentation(object_name):
             print ""
             sys.exit(0)
         elif len(arr) == 3 and ".".join(arr[:2]) == test_class_name:
-            #get the method info
+            # get the method info
             print utils.format(getattr(test_class, arr[2]).__doc__)
             print ""
             sys.exit(0)
@@ -380,9 +395,12 @@ def print_documentation(object_name):
     print "The test name specified (%s) was incorrect. Please specify the full test name." % object_name
     sys.exit(0)
 
+
 def enumerate_all_test_classes():
-    tg = TestGenerator('nonexistent_session', 'nonexistent_config', 'nonexistent_iface')
+    tg = TestGenerator('nonexistent_session',
+                       'nonexistent_config', 'nonexistent_iface')
     return tg.get_test_classes()
+
 
 def print_all_test_classes():
     print "---------- %s ---------" % utils.bold("Test List")
@@ -392,4 +410,3 @@ def print_all_test_classes():
         for test_name in obj.list_tests():
             print "%s.%s" % (test_class_name, test_name)
     sys.exit(0)
-

--- a/autocertkit/test_report.py
+++ b/autocertkit/test_report.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """Module for analysing test kit XML output in order to provide a useful overview to the caller."""
@@ -36,6 +36,7 @@ from xml.dom import minidom
 from utils import *
 from models import *
 
+
 def count_by_result(class_recs, fn):
     """Return the list of tests which passed"""
 
@@ -44,12 +45,15 @@ def count_by_result(class_recs, fn):
     for class_name, (method_list, test_class_caps) in class_recs.iteritems():
         for method in method_list:
             if fn(method['result']):
-                test_matches.append("%s.%s" % (class_name, method['test_name']))
+                test_matches.append("%s.%s" %
+                                    (class_name, method['test_name']))
 
     return test_matches
 
+
 def wrap_text(string, width):
     return textwrap.wrap(string.strip(), width, subsequent_indent=' ' * 5)
+
 
 def print_system_info(stream):
     """ Retrieve system information from SMBIOS and write to given stream. """
@@ -60,9 +64,10 @@ def print_system_info(stream):
     stream.write("#########################\n")
     stream.write("\n")
 
+
 def post_test_report(xml_file, output_file):
     devices = create_models(xml_file)
-    
+
     all_passed = True
     fh = open(output_file, 'w')
     print_system_info(fh)

--- a/autocertkit/testbase.py
+++ b/autocertkit/testbase.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """Module for base test clasess from which test cases are derived"""
@@ -35,6 +35,7 @@ import re
 import signal
 from utils import *
 log = get_logger('auto-cert-kit')
+
 
 class TestClass(object):
     """The base test class for defining attributes
@@ -61,7 +62,7 @@ class TestClass(object):
         global config used by each test case"""
         self.config = config
         self.session = session
-        #Take a copy of the tag list and then append.
+        # Take a copy of the tag list and then append.
         self.tags = list(self.tags)
         self.tags.append(self.base_tag)
         self.extra_init()
@@ -74,7 +75,7 @@ class TestClass(object):
         extra initialisation"""
         # Make sure we only run this on test run.
         if 'device_config' in self.config.keys():
-            self.generate_static_net_conf()        
+            self.generate_static_net_conf()
 
     def host_setup(self):
         """Method for running setup commands on a host
@@ -92,7 +93,7 @@ class TestClass(object):
         tests = self.list_tests()
         if test_name:
             arr = test_name.split('.')
-            test_name = arr[len(arr)-1]
+            test_name = arr[len(arr) - 1]
             log.debug("Test Selected = %s" % test_name)
         for test in tests:
             if test_name and test_name != test:
@@ -103,26 +104,29 @@ class TestClass(object):
                 sm.release_all()
 
             # Release Alarm signal to prevent handled signal from previous test
-            # interrupts this test. When there is no SIG_ALRM, this does nothing.
+            # interrupts this test. When there is no SIG_ALRM, this does
+            # nothing.
             signal.alarm(0)
 
             rec = {}
             try:
-                log.debug("******** %s.%s ********" % (self.__class__.__name__, test))
+                log.debug("******** %s.%s ********" %
+                          (self.__class__.__name__, test))
                 res = getattr(self, test)(self.session)
 
-                # If test executed without failure it can be either skipped or passed.
+                # If test executed without failure it can be either skipped or
+                # passed.
                 if 'skipped' in res and res['skipped']:
                     rec['result'] = 'skip'
                 else:
                     rec['result'] = 'pass'
 
-                def copy_field(rec, res, field, keep_tag = True):
+                def copy_field(rec, res, field, keep_tag=True):
                     if field in res:
                         rec[field] = res[field]
                     elif keep_tag:
                         rec[field] = ""
-                
+
                 copy_field(rec, res, 'info')
                 copy_field(rec, res, 'data')
                 copy_field(rec, res, 'config')
@@ -137,7 +141,8 @@ class TestClass(object):
                 log.error("Test Case Failure: %s" % str(test))
                 log.debug(traceb)
                 if debug:
-                    log.debug("Running in debug mode - exiting due to failure: %s" % str(e))
+                    log.debug(
+                        "Running in debug mode - exiting due to failure: %s" % str(e))
                     sys.exit(0)
             except:
                 traceb = traceback.format_exc()
@@ -145,12 +150,14 @@ class TestClass(object):
                 rec['result'] = 'fail'
                 rec['trackeback'] = traceb
                 rec['exception'] = "Unexpected error: %s" % sys.exc_info()[0]
-                log.debug(traceb)  
+                log.debug(traceb)
                 if debug:
-                    log.debug("Running in debug mode - exiting due to failure: %s" % sys.exc_info()[0])
+                    log.debug(
+                        "Running in debug mode - exiting due to failure: %s" % sys.exc_info()[0])
                     sys.exit(0)
 
-            log.debug("Test case %s: %s.%s" % (rec['result'], self.__class__.__name__, test))
+            log.debug("Test case %s: %s.%s" %
+                      (rec['result'], self.__class__.__name__, test))
             rec['test_name'] = "%s.%s" % (self.__class__.__name__, test)
             results.append(rec)
             pool_wide_cleanup(self.session)
@@ -164,7 +171,8 @@ class TestClass(object):
         for tag in self.required_config:
             log.debug("Checking for %s" % tag)
             if tag not in self.config or not self.config[tag]:
-                raise Exception("Prerequisite '%s' has not been passed to this object" % tag)
+                raise Exception(
+                    "Prerequisite '%s' has not been passed to this object" % tag)
             else:
                 log.debug("Tag %s: %s" % (tag, self.config[tag]))
 
@@ -179,9 +187,9 @@ class TestClass(object):
 
     def list_tests(self):
         """Return a list of tests contained within this class"""
-        method_list = [method for method in dir(self) 
-                      if callable(getattr(self,method)) 
-                      and method.startswith('test')]
+        method_list = [method for method in dir(self)
+                       if callable(getattr(self, method))
+                       and method.startswith('test')]
         return method_list
 
     def is_required(self):
@@ -213,30 +221,31 @@ class TestClass(object):
         res = {}
         regex = re.compile(r'static_(?P<netid>\d+)_(?P<vlan>\d+)')
 
-        # Iterate through the network config structure to 
+        # Iterate through the network config structure to
         # see if we have any static managers to initialise.
         for k, v in self.get_netconf().iteritems():
-            # We only care about vlans on the physical network ID this test is running on
+            # We only care about vlans on the physical network ID this test is
+            # running on
 
             match = regex.search(k)
             if match:
                 network_id = int(match.group('netid'))
                 vlan = match.group('vlan')
-                log.debug("Static Config Record for Netid %d and Vlan %s" % \
-                            (network_id, vlan))
+                log.debug("Static Config Record for Netid %d and Vlan %s" %
+                          (network_id, vlan))
                 sm = StaticIPManager(v)
 
                 # We must assign this static manager to all of the network references
                 # which have the netid that has been specified.
-                if network_id in netid_rec.keys():    
+                if network_id in netid_rec.keys():
                     for iface in netid_rec[network_id]:
-                        log.debug("Create static config for %s (%s)" % (iface, vlan))
+                        log.debug("Create static config for %s (%s)" %
+                                  (iface, vlan))
                         key_name = "%s_%s" % (iface, vlan)
                         assert(key_name not in res.keys())
                         res[key_name] = sm
                         log.debug("Added static conf for '%s'" % key_name)
 
-        
         self.static_managers = res
         log.debug("Static Managers Created: %s" % self.static_managers)
 
@@ -251,12 +260,12 @@ class TestClass(object):
         # Note: we expect two devices for the case where we have created
         # a bond between two PIFs.
         if len(devices) > 2:
-            raise Exception("Error: more than two devices " \
+            raise Exception("Error: more than two devices "
                             + "for network %s: %s" % (network_ref, devices))
 
         # In the case of a bond, we do not mind which device is used.
         iface = devices.pop()
-    
+
         key = "%s_%s" % (iface, vlan)
         if key in self.static_managers.keys():
             return self.static_managers[key]
@@ -285,7 +294,7 @@ class TestClass(object):
 
         equiv_ifaces = intersection(get_equivalent_devices(self.session,
                                                            self.config['device_config']),
-                                                           self.get_netconf().keys())
+                                    self.get_netconf().keys())
 
         log.debug("Equivalent devices for %s: %s" % (self.config['device_config']['Kernel_name'],
                                                      equiv_ifaces))
@@ -296,7 +305,8 @@ class TestClass(object):
         try:
             return filter_pif_devices(self.session, equiv_devs)
         except Exception, e:
-            log.error("Caught Exception - may be OK if running in single NIC mode.")
+            log.error(
+                "Caught Exception - may be OK if running in single NIC mode.")
             log.error("Exception Occurred: %s" % str(e))
             if self.singlenicmode():
                 return equiv_devs
@@ -312,36 +322,37 @@ class TestClass(object):
         if self.singlenicmode():
             devices = device_list
         else:
-            #Get no management ethernet devices
+            # Get no management ethernet devices
             devices = filter_pif_devices(self.session, device_list)
 
         results = []
         for device in devices:
-            #Array access exception would be raised by filter_pif_devices
-            pifs = get_pifs_by_device(self.session, device) 
+            # Array access exception would be raised by filter_pif_devices
+            pifs = get_pifs_by_device(self.session, device)
 
-            #Assumption that two PIFs are on the same network
+            # Assumption that two PIFs are on the same network
             network_ref = self.session.xenapi.PIF.get_network(pifs[0])
             if len(pifs) > 1:
                 for pif in pifs[1:]:
                     if self.session.xenapi.PIF.get_network(pif) != network_ref:
-                        raise Exception("Assumption that identical devices " + 
-                                        "in a pool are attached to the same " + 
+                        raise Exception("Assumption that identical devices " +
+                                        "in a pool are attached to the same " +
                                         "network is invalid!")
             results.append(network_ref)
 
-        #Raise an exception if no networks have been found
+        # Raise an exception if no networks have been found
         if not len(results):
             raise Exception("No non-management networks have been found")
 
         return results
+
 
 class NetworkTestClass(TestClass):
     """Sub class for Network Tests"""
     base_tag = 'NA'
     network_backend = 'vswitch'
     num_ips_required = 0
-    
+
     def host_setup(self):
         """Overload setup function. Setup networking backend"""
         host_refs = self.session.xenapi.host.get_all()
@@ -358,16 +369,16 @@ class NetworkTestClass(TestClass):
         log.debug("Current network backend: %s" % backend)
         log.debug("self.network_backend %s" % self.network_backend)
         if self.network_backend == 'vswitch' and backend == 'bridge':
-            #Switch backend to vswitch
+            # Switch backend to vswitch
             call_ack_plugin(self.session, 'set_network_backend_pool',
                             {'backend': 'openvswitch'})
             host_reboot(self.session)
         elif self.network_backend == 'bridge' and backend == 'openvswitch':
-            #Switch backend to bridge
+            # Switch backend to bridge
             call_ack_plugin(self.session, 'set_network_backend_pool',
                             {'backend': 'bridge'})
             host_reboot(self.session)
-        #Nothing to do, just return
+        # Nothing to do, just return
         return
 
     def get_bondable_ifaces(self, iface):
@@ -382,7 +393,7 @@ class NetworkTestClass(TestClass):
 
         blist = intersection([k for k, v in netconf.iteritems() if k.startswith('eth') and
                               v['network_id'] == phy_id],
-                          netconf.keys())
+                             netconf.keys())
 
         # Need to remove any occurances of the given interface, as we can't bond
         # with ourselves.
@@ -401,18 +412,20 @@ class NetworkTestClass(TestClass):
         for iface in self.get_equivalent_devices():
             if self.get_bondable_ifaces(iface):
                 res.append(iface)
-                
+
         return res
+
 
 class LocalStorageTestClass(TestClass):
     """Sub class for storage tests"""
     base_tag = 'LS'
 
+
 class CPUTestClass(TestClass):
     """Sub class for CPU tests"""
     base_tag = 'CPU'
 
+
 class OperationsTestClass(TestClass):
     """Sub class for Operations tests"""
     base_tag = 'OP'
-

--- a/autocertkit/tests/frontend-test.py
+++ b/autocertkit/tests/frontend-test.py
@@ -2,7 +2,8 @@
 
 import unittest
 import sys
-import os, os.path
+import os
+import os.path
 import random
 import exceptions
 import tempfile
@@ -12,13 +13,13 @@ from autocertkit import utils, ack_cli
 
 utils.configure_logging('ack_tests')
 
+
 class NetworkConfRobustTests(unittest.TestCase):
     """ Checking functionality and robust of netconf parser. """
 
     TMP_DIR = None
     PREFIX = "sameple_netconf_"
     CLEANUP_LIST = []
-
 
     def _create_netconf_file(self, content):
         fullpath = self.TMP_DIR + os.sep + self.PREFIX + str(random.random())
@@ -43,34 +44,34 @@ class NetworkConfRobustTests(unittest.TestCase):
         if os.path.exists(self.TMP_DIR):
             shutil.rmtree(self.TMP_DIR)
 
-    def _runTest(self, content, output = None, exception = None):
+    def _runTest(self, content, output=None, exception=None):
         filename = self._create_netconf_file(content)
         if exception:
             self.assertRaises(exception, ack_cli.parse_netconf_file, filename)
         else:
             self.assertTrue(ack_cli.parse_netconf_file(filename) == output)
-        
+
     def testExampleNetconf(self):
         output = {'static_0_200': {'gw': '192.168.0.1',
-                                'netmask': '255.255.255.0',
-                                'ip_end': '192.168.0.10',
-                                'ip_start': '192.168.0.2'},
-                'eth0': {'network_id': 0, 'vlan_ids': [200, 204, 240]},
-                'eth1': {'network_id': 1, 'vlan_ids': [200, 124]},
-                'eth2': {'network_id': 0, 'vlan_ids': [204, 240]},
-                'eth3': {'network_id': 1, 'vlan_ids': [200]}
-                }
+                                   'netmask': '255.255.255.0',
+                                   'ip_end': '192.168.0.10',
+                                   'ip_start': '192.168.0.2'},
+                  'eth0': {'network_id': 0, 'vlan_ids': [200, 204, 240]},
+                  'eth1': {'network_id': 1, 'vlan_ids': [200, 124]},
+                  'eth2': {'network_id': 0, 'vlan_ids': [204, 240]},
+                  'eth3': {'network_id': 1, 'vlan_ids': [200]}
+                  }
 
-        self.assertTrue(ack_cli.parse_netconf_file("autocertkit/networkconf.example") == output)
-
+        self.assertTrue(ack_cli.parse_netconf_file(
+            "autocertkit/networkconf.example") == output)
 
     def testSimple2Nic(self):
         content = """eth0 = 0,[0]
 eth1 = 0,[0]
 """
         output = {'eth0': {'network_id': 0, 'vlan_ids': [0]},
-                 'eth1': {'network_id': 0, 'vlan_ids': [0]},
-                }
+                  'eth1': {'network_id': 0, 'vlan_ids': [0]},
+                  }
         self._runTest(content, output)
 
     def testWhiteSpace(self):
@@ -78,8 +79,8 @@ eth1 = 0,[0]
 	eth1=0,[0]
 """
         output = {'eth0': {'network_id': 0, 'vlan_ids': [0]},
-                 'eth1': {'network_id': 0, 'vlan_ids': [0]},
-                }
+                  'eth1': {'network_id': 0, 'vlan_ids': [0]},
+                  }
         self._runTest(content, output)
 
     def testEmptyLinesAndComments(self):
@@ -94,8 +95,8 @@ eth1 = 0, [0]
  # comment following space.
 """
         output = {'eth0': {'network_id': 0, 'vlan_ids': [0]},
-                 'eth1': {'network_id': 0, 'vlan_ids': [0]},
-                }
+                  'eth1': {'network_id': 0, 'vlan_ids': [0]},
+                  }
         self._runTest(content, output)
 
     def testStaticIP(self):
@@ -104,12 +105,12 @@ eth1=0,[0]
 static_0_0 = 192.168.0.2,192.168.0.10,255.255.255.0,192.168.0.1
 """
         output = {'static_0_0': {'gw': '192.168.0.1',
-                                'netmask': '255.255.255.0',
-                                'ip_end': '192.168.0.10',
-                                'ip_start': '192.168.0.2'},
-                 'eth0': {'network_id': 0, 'vlan_ids': [0]},
-                 'eth1': {'network_id': 0, 'vlan_ids': [0]},
-                }
+                                 'netmask': '255.255.255.0',
+                                 'ip_end': '192.168.0.10',
+                                 'ip_start': '192.168.0.2'},
+                  'eth0': {'network_id': 0, 'vlan_ids': [0]},
+                  'eth1': {'network_id': 0, 'vlan_ids': [0]},
+                  }
         self._runTest(content, output)
 
     def testStaticIPWrong(self):
@@ -148,4 +149,3 @@ eth1 = 0
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/autocertkit/tests/model_tests.py
+++ b/autocertkit/tests/model_tests.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python
 
-import unittest, unittest_base
+import unittest
+import unittest_base
 from autocertkit import utils, test_generators, models
 from xml.dom import minidom
 
+
 class StreamMock(object):
     """Fake stream to get result."""
+
     def __init__(self):
         self.__data = ""
 
@@ -20,15 +23,15 @@ class ReportPrintsTests(unittest_base.DevTestCase):
     """Test Report output is generated properly"""
 
     device = {'vendor': 'fakevender',
-            'PCI_id': 'fakeid',
-            'PCI_subsystem': 'fakess',
-            'device': 'fakedevice',
-            'driver': 'fake',
-            'PCI_description': 'fakedesc',
-            'modelname': 'fake AMD model',
-            'version': 'fakeversion',
-            'build': 'fakebuildnumber'
-            }
+              'PCI_id': 'fakeid',
+              'PCI_subsystem': 'fakess',
+              'device': 'fakedevice',
+              'driver': 'fake',
+              'PCI_description': 'fakedesc',
+              'modelname': 'fake AMD model',
+              'version': 'fakeversion',
+              'build': 'fakebuildnumber'
+              }
     config = {'exclude': ['LSTOR', 'OVS', 'BRIDGE', 'OPS', 'CPU']}
 
     def createDeviceNode(self, generator):
@@ -43,20 +46,22 @@ class ReportPrintsTests(unittest_base.DevTestCase):
         device_node.appendChild(cts_node)
 
         return device_node
-        
+
     def testLSReport(self):
-        device_node = self.createDeviceNode(test_generators.StorageTestGenerator)
+        device_node = self.createDeviceNode(
+            test_generators.StorageTestGenerator)
         report = StreamMock()
         models.Device(device_node).print_report(report)
 
-        assert 'fakevender:fakedevice' in report.output(), "Failed to compile vender and device."
+        assert 'fakevender:fakedevice' in report.output(
+        ), "Failed to compile vender and device."
         expected = "Storage device using the fake driver"
         assert expected in report.output(), "Failed to compile driver."
         assert 'fakedesc' in report.output(), "Failed to compile PCI_description."
 
-
     def testNetReport(self):
-        device_node = self.createDeviceNode(test_generators.NetworkAdapterTestGenerator)
+        device_node = self.createDeviceNode(
+            test_generators.NetworkAdapterTestGenerator)
         report = StreamMock()
         models.Device(device_node).print_report(report)
 
@@ -65,14 +70,16 @@ class ReportPrintsTests(unittest_base.DevTestCase):
         assert 'fakess' in report.output(), "Failed to compile PCI_subsystem."
 
     def testCPUReport(self):
-        device_node = self.createDeviceNode(test_generators.ProcessorTestGenerator)
+        device_node = self.createDeviceNode(
+            test_generators.ProcessorTestGenerator)
         report = StreamMock()
         models.Device(device_node).print_report(report)
 
         assert 'fake AMD model' in report.output(), "Failed to compile model name"
 
     def testOpsReport(self):
-        device_node = self.createDeviceNode(test_generators.OperationsTestGenerator)
+        device_node = self.createDeviceNode(
+            test_generators.OperationsTestGenerator)
         report = StreamMock()
         models.Device(device_node).print_report(report)
 

--- a/autocertkit/tests/test_generators_tests.py
+++ b/autocertkit/tests/test_generators_tests.py
@@ -7,12 +7,13 @@ from autocertkit import test_generators, testbase, utils
 
 utils.configure_logging('ack_tests')
 
+
 def expect_system_exit(func, code='0'):
     try:
         func()
     except SystemExit as exp:
         if str(exp) == code:
-            #Valid System Exit
+            # Valid System Exit
             pass
         else:
             raise exp
@@ -23,10 +24,11 @@ class DocumentationTests(unittest_base.DevTestCase):
 
     def testPrintTestList(self):
         expect_system_exit(test_generators.print_all_test_classes)
-    
+
     def testPrintClassInformation(self):
         for test_class_name, test_class in test_generators.enumerate_all_test_classes():
-            expect_system_exit(lambda: test_generators.print_documentation(test_class_name))
+            expect_system_exit(
+                lambda: test_generators.print_documentation(test_class_name))
 
     def testClassDescrition(self):
         """Make sure that each test class has a defined docstring outlining
@@ -37,7 +39,8 @@ class DocumentationTests(unittest_base.DevTestCase):
                 classes_without_docstrings.append(test_class_name)
 
         if classes_without_docstrings:
-            raise Exception("These classes have no docstrings: %s" % classes_without_docstrings)
+            raise Exception("These classes have no docstrings: %s" %
+                            classes_without_docstrings)
 
 
 if __name__ == '__main__':

--- a/autocertkit/tests/testbase_tests.py
+++ b/autocertkit/tests/testbase_tests.py
@@ -7,6 +7,7 @@ import sys
 
 utils.configure_logging('ack_tests')
 
+
 class TagsTests(unittest_base.DevTestCase):
     """Test that tags are enumerated correctly for a specified testclass"""
 
@@ -18,9 +19,10 @@ class TagsTests(unittest_base.DevTestCase):
     def testForTagMutilation(self):
         tg = test_generators.TestGenerator('fake_session', {}, 'nonexistent')
         for test_name, test_class in tg.get_test_classes():
-            orig_tags = list(test_class('fake_session',{}).tags)
-            new_tags = test_class('fake_session',{}).tags
-            assert orig_tags == new_tags, "%s != %s - Tags are being mutilated. (%s)" % (orig_tags, new_tags, test_name)
+            orig_tags = list(test_class('fake_session', {}).tags)
+            new_tags = test_class('fake_session', {}).tags
+            assert orig_tags == new_tags, "%s != %s - Tags are being mutilated. (%s)" % (
+                orig_tags, new_tags, test_name)
 
 if __name__ == '__main__':
     unittest.main()

--- a/autocertkit/tests/unittest_base.py
+++ b/autocertkit/tests/unittest_base.py
@@ -6,6 +6,7 @@ import sys
 
 import autocertkit.utils
 
+
 class DevTestCase(unittest.TestCase):
     """Subclass unittest for extended setup/tear down
     functionality"""
@@ -15,10 +16,10 @@ class DevTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        #Read user config from file
+        # Read user config from file
         pass
 
     @classmethod
     def tearDownClass(cls):
-        #Destroy the session
-        pass 
+        # Destroy the session
+        pass

--- a/autocertkit/tests/utils_tests.py
+++ b/autocertkit/tests/utils_tests.py
@@ -16,6 +16,7 @@ K = 1024
 M = K * 1024
 G = M * 1024
 
+
 class ExpressionMatchingTests(unittest_base.DevTestCase):
     """Tests for checking that the expr_eval function
     works appropriately with XenServer version numbers"""
@@ -26,20 +27,21 @@ class ExpressionMatchingTests(unittest_base.DevTestCase):
 
     def _exp_false(self, expr, val):
         res = utils.eval_expr(expr, val)
-        self.assertEqual(res, False, "Expected %s %s to be False!" % (val, expr))
+        self.assertEqual(
+            res, False, "Expected %s %s to be False!" % (val, expr))
 
     def testGreaterThanTrue(self):
         self._exp_true('> 5.6', '6.0.0')
         self._exp_true('> 5.6', '5.6 FP1')
         self._exp_true('> 5.6 FP1', '5.6 SP2')
         self._exp_true('> 5.6 SP2', '6.0.0')
-    
+
     def testGreaterThanFalse(self):
         self._exp_false('> 6.0.0', '5.6 SP2')
         self._exp_false('> 6.0.0', '5.6 FP1')
         self._exp_false('> 6.0.0', '5.6')
         self._exp_false('> 5.6 SP2', '5.6 FP1')
-        
+
 
 class StaticIPUtilsTests(unittest_base.DevTestCase):
     """Verify that the class methods for manipulating
@@ -54,8 +56,9 @@ class StaticIPUtilsTests(unittest_base.DevTestCase):
                                                                      ip_b,
                                                                      mask,
                                                                      expect))
+
     def _test_increment_ip(self, start, result, expect=True):
-        conf = {'ip_start':'192.168.0.1',
+        conf = {'ip_start': '192.168.0.1',
                 'ip_end': '192.168.0.10',
                 'netmask': '255.255.255.0',
                 'gw': '192.168.0.1'}
@@ -77,14 +80,13 @@ class StaticIPUtilsTests(unittest_base.DevTestCase):
                              '192.128.0.40',
                              '255.255.255.0',
                              expect=False)
-                          
-    
+
     def testIncrementIPs(self):
-        self._test_increment_ip('192.168.0.1','192.168.0.2')
-        self._test_increment_ip('192.168.0.1','192.168.0.10', expect=False)
+        self._test_increment_ip('192.168.0.1', '192.168.0.2')
+        self._test_increment_ip('192.168.0.1', '192.168.0.10', expect=False)
 
     def testEnumerateIPs(self):
-        conf = {'ip_start':'10.80.227.143',
+        conf = {'ip_start': '10.80.227.143',
                 'ip_end': '10.80.227.151',
                 'netmask': '255.255.0.0',
                 'gw': '10.80.227.1'}
@@ -97,16 +99,16 @@ class StaticIPUtilsTests(unittest_base.DevTestCase):
         free_list = sim.ip_pool
 
         if len(free_list) != len(full_list):
-            raise Exception("Error: we expect there to be %d IPs, enumerate produced %d." % 
+            raise Exception("Error: we expect there to be %d IPs, enumerate produced %d." %
                             (len(full_list), len(free_list)))
 
         for i in range(len(full_list)):
             if free_list[i].addr != full_list[i]:
                 raise Exception("Error: Enumerate IP returns %s, we expect %s" % (free_list,
-                                                                              full_list))
+                                                                                  full_list))
 
     def testLoanStaticIP(self):
-        conf = {'ip_start':'192.168.0.5',
+        conf = {'ip_start': '192.168.0.5',
                 'ip_end': '192.168.0.10',
                 'netmask': '255.255.255.0',
                 'gw': '192.168.0.1'}
@@ -116,33 +118,33 @@ class StaticIPUtilsTests(unittest_base.DevTestCase):
         borrowed_ip = sim.get_ip()
         assert(sim.available_ips() == 5)
         assert(len(sim.in_use) == 1)
-        
+
         sim.return_ip(borrowed_ip)
 
         assert(sim.available_ips() == 6)
         assert(len(sim.in_use) == 0)
 
-        
-class ValueInRangeFunctions(unittest.TestCase):
-    
-    def test_simple(self):
-        #Assert True
-        self.assertTrue(utils.value_in_range(5*G, 4*G, 8*G))
-        self.assertTrue(utils.value_in_range(3*G, 0, 4*G))
-        self.assertTrue(utils.value_in_range(4*G, 0, 4*G))
-        self.assertTrue(utils.value_in_range(3*G, 3*G, 4*G))
 
-        #Assert False
+class ValueInRangeFunctions(unittest.TestCase):
+
+    def test_simple(self):
+        # Assert True
+        self.assertTrue(utils.value_in_range(5 * G, 4 * G, 8 * G))
+        self.assertTrue(utils.value_in_range(3 * G, 0, 4 * G))
+        self.assertTrue(utils.value_in_range(4 * G, 0, 4 * G))
+        self.assertTrue(utils.value_in_range(3 * G, 3 * G, 4 * G))
+
+        # Assert False
         self.assertFalse(utils.value_in_range(4, 5, 500))
-        self.assertFalse(utils.value_in_range(4*G+1,0, 4*G))
-        self.assertFalse(utils.value_in_range(-1,0, 4*G))
+        self.assertFalse(utils.value_in_range(4 * G + 1, 0, 4 * G))
+        self.assertFalse(utils.value_in_range(-1, 0, 4 * G))
 
     def test_wrap(self):
         self.assertTrue(utils.wrapped_value_in_range(8, 5, 15, 10))
-        self.assertTrue(utils.wrapped_value_in_range(5*K, 3*G, 5*G))
-        self.assertTrue(utils.wrapped_value_in_range(3*G, 2*G, 4*G))
-        self.assertFalse(utils.wrapped_value_in_range(1*G, 2*G, 4*G))
-        self.assertFalse(utils.wrapped_value_in_range(2*G, 3*G, 5*G))
+        self.assertTrue(utils.wrapped_value_in_range(5 * K, 3 * G, 5 * G))
+        self.assertTrue(utils.wrapped_value_in_range(3 * G, 2 * G, 4 * G))
+        self.assertFalse(utils.wrapped_value_in_range(1 * G, 2 * G, 4 * G))
+        self.assertFalse(utils.wrapped_value_in_range(2 * G, 3 * G, 5 * G))
 
         self.assertTrue(utils.wrapped_value_in_range(3965952210,
                                                      8248029658,
@@ -163,7 +165,6 @@ class ValidatePingResponses(unittest.TestCase):
         response = "20 packets transmitted, 19 received, 5% packet loss, time 19008ms"
         self.assertTrue(utils.valid_ping_response(response, max_loss=5))
 
-        
 
 class RebootFlagTimestamps(unittest.TestCase):
 
@@ -206,15 +207,16 @@ class HostLibMethodsTests(unittest.TestCase):
         utils.wait_for_hosts(self.session)
 
         self.session.hosts[0].enabled = False
-        self.assertRaises(Exception, \
-                lambda: utils.wait_for_hosts(self.session, timeout=1))
+        self.assertRaises(Exception,
+                          lambda: utils.wait_for_hosts(self.session, timeout=1))
 
-        self.session.hosts[0].enabled = True 
+        self.session.hosts[0].enabled = True
         self.session.hosts[1].metrics.live = False
-        self.assertRaises(Exception, \
-                lambda: utils.wait_for_hosts(self.session, timeout=1))
+        self.assertRaises(Exception,
+                          lambda: utils.wait_for_hosts(self.session, timeout=1))
 
         self.__enable_all_hosts()
+
 
 class PoolLibMethodsTests(unittest.TestCase):
     """
@@ -225,12 +227,12 @@ class PoolLibMethodsTests(unittest.TestCase):
         self.session = xenapi_mock.Session()
 
     def test_get_pool_master(self):
-        self.assertTrue(utils.get_pool_master(self.session) == \
-                self.session.hosts[0].opaque)
+        self.assertTrue(utils.get_pool_master(self.session) ==
+                        self.session.hosts[0].opaque)
 
     def test_get_pool_slaves(self):
-        self.assertTrue(utils.get_pool_slaves(self.session) == \
-                [host.opaque for host in self.session.hosts[1:]])
+        self.assertTrue(utils.get_pool_slaves(self.session) ==
+                        [host.opaque for host in self.session.hosts[1:]])
 
 
 class SimpleMethodsTests(unittest.TestCase):
@@ -246,4 +248,3 @@ class SimpleMethodsTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/autocertkit/tests/xenapi_mock.py
+++ b/autocertkit/tests/xenapi_mock.py
@@ -9,6 +9,7 @@ import mock
 import random
 import json
 
+
 class XenAPIObjectMock(object):
     """Base class for XenAPI object models"""
 
@@ -23,11 +24,12 @@ class XenAPIObjectMock(object):
             suffix = '_%d' % random.randint(0, 9999999)
         cls.USED_SUFFIXES.append(suffix)
 
-        return ('Opaque: %sOpaque%s' % (clsname, suffix), \
+        return ('Opaque: %sOpaque%s' % (clsname, suffix),
                 '%sUUID%s' % (clsname, suffix))
 
     def __init__(self):
-        self.__opaque, self.__uuid = self.__class__.genIdentity(self.__class__.__name__)
+        self.__opaque, self.__uuid = self.__class__.genIdentity(
+            self.__class__.__name__)
 
     @property
     def opaque(self):
@@ -123,7 +125,7 @@ class PIF(XenAPIObjectMock):
 
     @property
     def plugged(self):
-        return  self.__plugged
+        return self.__plugged
 
     @plugged.setter
     def plugged(self, value):
@@ -169,11 +171,11 @@ class Host(XenAPIObjectMock):
         super(Host, self).__init__()
         self.__metrics = HostMetrics()
         self.__pifs = [PIF(self, networks[i], i * 2) for i in xrange(len(networks))] + \
-                [PIF(self, networks[i], i * 2 + 1) for i in xrange(len(networks))]
+            [PIF(self, networks[i], i * 2 + 1) for i in xrange(len(networks))]
         for pif in self.__pifs:
             pif.network.addPIF(pif)
         self.__enabled = True
-        self.__vms = [VM(self, True)] # Control Domain
+        self.__vms = [VM(self, True)]  # Control Domain
 
     @property
     def enabled(self):
@@ -232,7 +234,7 @@ class VM(XenAPIObjectMock):
 
     @property
     def record(self):
-        return {'is_control_domain': self.__controlDomain, \
+        return {'is_control_domain': self.__controlDomain,
                 'resident_on': self.__host.opaque}
 
     @property
@@ -423,4 +425,3 @@ class XenapiVMMock(mock.Mock):
                 rec[vm.opaque] = vm.record
 
         return rec
-

--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1,31 +1,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 """A module for utility functions shared with multiple test cases"""
@@ -70,48 +70,63 @@ REQ_CAP = "REQ"
 # XAPI States
 XAPI_RUNNING_STATE = "Running"
 
+
 class TestCaseError(Exception):
     """A subclassed exception object, which is raised by any
     test failure"""
+
     def __init__(self, *args):
         self.value = args[0]
         Exception.__init__(self, *args)
+
     def __str__(self):
         return repr("TEST_CASE_ERROR: %s" % self.value)
 
+
 class TimeoutFunctionException(Exception):
     """Exception to raise on a timeout"""
+
     def __init__(self, *args):
         self.value = args[0]
         Exception.__init__(self, *args)
+
     def __str__(self):
         return repr("TIMEOUT_EXCEPTION: %s" % self.value)
 
+
 class ArgumentError(Exception):
     """Raised when a user provides incomplete or missing arguments"""
+
     def __init__(self, *args):
         Exception.__init__(self, *args)
 
+
 class ConfigFileNotFound(Exception):
     """Raised when a user provides incomplete or missing arguments"""
+
     def __init__(self, *args):
         self.file_name = args[0]
         self.config = args[1]
         Exception.__init__(self, *args)
+
     def __str__(self):
         return repr("%s file not found: '%s'. Please re-specify." % (self.config, self.file_name))
 
 
 class InvalidArgument(ArgumentError):
     """Raised when a value provided as an argument is invalid"""
+
     def __init__(self, *args):
         self.arg_name = args[0]
         self.value = args[1]
         self.possibles = args[2]
+
     def __str__(self):
         return repr("INVALID_ARGUMENT: Argument Name: %s, Provided Value: '%s', Possible Options: %s" % (self.arg_name, self.value, self.possibles))
 
-##### Exception Decorator
+# Exception Decorator
+
+
 def log_exceptions(func):
     def decorated(*args, **kwargs):
         try:
@@ -120,16 +135,19 @@ def log_exceptions(func):
             log.error('%s: XenAPI.Failure: %s', func.__name__, str(e))
             raise
         except Exception, e:
-            log.error('%s: %s: %s', func.__name__, e.__class__.__name__, str(e))
+            log.error('%s: %s: %s', func.__name__,
+                      e.__class__.__name__, str(e))
             raise
     return decorated
 #############################
+
 
 def int_to_bin(x):
     if x == 0:
         return ''
     else:
-        return int_to_bin(x/2) + str(x%2)
+        return int_to_bin(x / 2) + str(x % 2)
+
 
 class IPv4Addr(object):
     """Class for storing information about IP address"""
@@ -144,10 +162,10 @@ class IPv4Addr(object):
     def validate_ip(self):
         arr = self.addr.split('.')
         if len(arr) != 4:
-            raise Exception("Error: IP address is not correct: '%s'" % 
+            raise Exception("Error: IP address is not correct: '%s'" %
                             self.addr)
 
-        for i in range(0,4):
+        for i in range(0, 4):
             if int(arr[i]) > 255:
                 raise Exception("IP address is out of range: %s" % self.addr)
 
@@ -161,12 +179,13 @@ class IPv4Addr(object):
 
         # For a netmask, we expect a contigious line of ones.
         zero_pos = mask_str.find('0')
-        
+
         if zero_pos == -1:
             return True
         else:
             if '1' in mask_str[zero_pos + 1:]:
-                raise Exception("Invalid netmask: '%s' ('%s')" % (self.netmask, mask_str))
+                raise Exception("Invalid netmask: '%s' ('%s')" %
+                                (self.netmask, mask_str))
 
     def to_bin(self, integer):
         """Convert an integer to a 8bit string"""
@@ -174,7 +193,7 @@ class IPv4Addr(object):
             raise Exception("'to_bin' method is only for 8bit integers")
 
         bin_str = int_to_bin(integer)[2:]
-        
+
         tmp_str = ""
         for i in range(8 - len(bin_str)):
             tmp_str = tmp_str + "0"
@@ -192,7 +211,8 @@ class IPv4Addr(object):
             elif mask[i] == '0':
                 continue
             else:
-                raise Exception("Unexpected characted '%s' in binary string." % mask[i])
+                raise Exception(
+                    "Unexpected characted '%s' in binary string." % mask[i])
 
         return True
 
@@ -213,15 +233,17 @@ class IPv4Addr(object):
 
             if not self.byte_mask_match(a, b, m):
                 return False
-        return True        
-        
+        return True
+
+
 def get_network_routes(session, host_ref, retry=6):
     """Return a list of NetRoute objects for this system"""
     attempt = retry
     while attempt:
         attempt -= 1
         try:
-            results = call_ack_plugin(session, 'get_host_routes', {}, host=host_ref)
+            results = call_ack_plugin(
+                session, 'get_host_routes', {}, host=host_ref)
         except:
             log.debug("Failed. retrying. (retry=%d)" % attempt)
             time.sleep(10)
@@ -234,7 +256,8 @@ def get_network_routes(session, host_ref, retry=6):
         routes.append(route_obj)
 
     return routes
-            
+
+
 class StaticIPManager(object):
     """Class for managing static IP address provided by
     the caller. Allows us to do simple 'leasing' operations"""
@@ -242,13 +265,13 @@ class StaticIPManager(object):
     def __init__(self, conf):
         # Populate the internal list of IPs
         free = []
-        for ip_addr in self.generate_ip_list(conf['ip_start'], 
-                                        conf['ip_end']):
+        for ip_addr in self.generate_ip_list(conf['ip_start'],
+                                             conf['ip_end']):
             free.append(IPv4Addr(ip_addr,
                                  conf['netmask'],
                                  conf['gw']))
 
-        self.ip_pool = free # All the list of IPs
+        self.ip_pool = free  # All the list of IPs
         self.in_use = []    # Index list of used IP from ip_pool.
         self.last_used = -1   # Index of IP lastly picked. Next will be 0.
         self.total_ips = len(free)
@@ -262,13 +285,14 @@ class StaticIPManager(object):
             try:
                 arr = str_ip.split('.')
                 res = []
-                for i in range(0,4):
+                for i in range(0, 4):
                     res.append(int(arr[i]))
                     if res[i] > 254:
                         raise Exception("Invalid IP %s" % str_ip)
                 return arr
             except Exception, e:
-                raise Exception("Error: '%s' is not a valid IPv4 Addr (%s)" % (str_ip,str(e)))
+                raise Exception(
+                    "Error: '%s' is not a valid IPv4 Addr (%s)" % (str_ip, str(e)))
 
         arr1 = validate_ip(ip_start)
         arr2 = validate_ip(ip_end)
@@ -277,8 +301,8 @@ class StaticIPManager(object):
             if int(arr2[i]) < int(arr1[i]):
                 raise Exception("IP start ('%s') must be smaller than IP end ('%s') (%s <  %s)" %
                                 (ip_start,
-                                ip_end, arr2[i], arr1[i]))
-        
+                                 ip_end, arr2[i], arr1[i]))
+
         res = []
 
         res.append(ip_start)
@@ -294,9 +318,9 @@ class StaticIPManager(object):
 
         # After exit, we must also add the last value
         res.append(ip_end)
-            
+
         return res
-        
+
     def increment_ip_string(self, string):
         chars = string.split('.')
         arr = []
@@ -327,15 +351,14 @@ class StaticIPManager(object):
         if arr[0] == 255:
             raise Exception("Error: Invalid to increment: %s" % string)
 
-        return "%s.%s.%s.%s" % (arr[0],arr[1],arr[2],arr[3])
-
+        return "%s.%s.%s.%s" % (arr[0], arr[1], arr[2], arr[3])
 
     def get_ip(self):
         """Return an unused IP object (if one exists)"""
         if len(self.in_use) >= self.total_ips:
             raise Exception("Error: no more IP addresses to allocate! (%d in use)" %
                             len(self.in_use))
-            
+
         index = (self.last_used + 1) % self.total_ips
         while True:
             if not index in self.in_use:
@@ -343,13 +366,14 @@ class StaticIPManager(object):
                 self.in_use.append(index)
                 return self.ip_pool[index]
             index = (index + 1) % self.total_ips
-                
+
     def return_ip(self, ip):
         """For a given IP object, attempt to remove from the 'in_use' list, and put
         it back into circulation for others to use"""
         if not ip in self.ip_pool:
             log.debug("IP(%s) does not exist in IP pool." % (ip,))
-            raise Exception("Trying to return an IP address that did not orginally exist!")
+            raise Exception(
+                "Trying to return an IP address that did not orginally exist!")
 
         index = self.ip_pool.index(ip)
         if index in self.in_use:
@@ -367,6 +391,7 @@ class StaticIPManager(object):
         """Return number of unused IP in IP pool"""
         return self.total_ips - len(self.in_use)
 
+
 class IfaceStats(object):
     """Class object for representing network statistics associated
        with an ethernet interface"""
@@ -374,12 +399,12 @@ class IfaceStats(object):
     # List of keys depended on by callers
     required_keys = ['rx_bytes', 'tx_bytes', 'arch']
 
-    def __init__(self,iface, rec):
+    def __init__(self, iface, rec):
         setattr(self, 'iface', iface)
         self.validate_args(rec)
-       
-        # Load all key/values into the class as attributes 
-        for k,v in rec.iteritems():
+
+        # Load all key/values into the class as attributes
+        for k, v in rec.iteritems():
             try:
                 setattr(self, k, int(v))
             except ValueError:
@@ -389,18 +414,21 @@ class IfaceStats(object):
         rec_keys = rec.keys()
         for key in self.required_keys:
             if key not in rec_keys:
-                raise Exception("Error: could not find key '%s'" % key + \
-                                " in iface statistics record '%s'" % rec) 
+                raise Exception("Error: could not find key '%s'" % key +
+                                " in iface statistics record '%s'" % rec)
+
 
 def is_64_bit(arch):
     """Check if platform type is 64 bit"""
     return arch in ['x86_64']
 
+
 def value_in_range(value, min_v, max_v):
     """Establish whether a value lies between two numbers"""
     return min_v <= value <= max_v
 
-def wrapped_value_in_range(value, min_v, max_v, wrap=4*G):
+
+def wrapped_value_in_range(value, min_v, max_v, wrap=4 * G):
     """The value is assumed to be wrapped at some point. The function
     must test whether the value falls within the expected range.
     e.g. if our range is between 15-25, but we wrap at 20, then the
@@ -410,11 +438,11 @@ def wrapped_value_in_range(value, min_v, max_v, wrap=4*G):
         raise Exception("Error: the value is greater/equal than the wrap")
 
     if min_v > max_v:
-        raise Exception("Error: min must be greated than max. %d %d" % \
+        raise Exception("Error: min must be greated than max. %d %d" %
                         (min_v, max_v))
 
     if min_v - max_v >= wrap:
-        raise Exception("Error: cannot accurately determine if value " + \
+        raise Exception("Error: cannot accurately determine if value " +
                         "is in a range that is the space of a wrap")
 
     # This is a normal comparison opp
@@ -446,11 +474,12 @@ def wrapped_value_in_range(value, min_v, max_v, wrap=4*G):
 
     return False
 
+
 class IperfTestStatsValidator(object):
 
     warn_threshold = 5
     error_threshold = 10
-    
+
     def __init__(self, pre_stats, post_stats):
         setattr(self, 'pre', pre_stats)
         setattr(self, 'post', post_stats)
@@ -461,9 +490,9 @@ class IperfTestStatsValidator(object):
     def value_in_range(self, value, min_v, max_v):
         ret = value_in_range(value, min_v, max_v)
         if not ret and not is_64_bit(self.arch):
-            log.debug("IfaceStats 32bit and value is not in rage." \
-                    "Try checking with wrapped value. (%s)" % self.arch)
-            ret = wrapped_value_in_range(value, min_v, max_v, 4*G)
+            log.debug("IfaceStats 32bit and value is not in rage."
+                      "Try checking with wrapped value. (%s)" % self.arch)
+            ret = wrapped_value_in_range(value, min_v, max_v, 4 * G)
         return ret
 
     def validate_bytes(self, sent_bytes, attr):
@@ -482,19 +511,19 @@ class IperfTestStatsValidator(object):
         log.debug("high_lim = %d" % high_lim)
 
         if not self.value_in_range(post_bytes, low_lim, warn_lim):
-            log.debug("Warning: limit not within warning range. (%d)" % \
-                     self.warn_threshold)
+            log.debug("Warning: limit not within warning range. (%d)" %
+                      self.warn_threshold)
 
         if not self.value_in_range(post_bytes, low_lim, high_lim):
-            raise Exception("Error: mismatch in expected number " + \
-                                " of bytes")
+            raise Exception("Error: mismatch in expected number " +
+                            " of bytes")
         return True
 
 
 class Iface(object):
     """Class representing an ethernet interface"""
-    
-    required_keys = ["ip","mask","mac"]
+
+    required_keys = ["ip", "mask", "mac"]
 
     def __init__(self, rec):
         self.validate_rec(rec)
@@ -513,15 +542,18 @@ class Iface(object):
             rec[key] = getattr(self, key)
         return rec
 
-##### Logging setup
+# Logging setup
 
 log = None
+
+
 def configure_logging(name):
     """Method for configuring Logging"""
     global log
     if not log:
         log = acktools.log.configure_log(name, LOG_LOC)
     return log
+
 
 def release_logging():
     """Release logging object."""
@@ -532,9 +564,11 @@ def release_logging():
 if not log:
     log = configure_logging('auto-cert-kit')
 
+
 def get_logger(name):
     """Method to return instance of logger"""
     return logging.getLogger(name)
+
 
 def get_local_xapi_session():
     """Login to Xapi locally. This will only work if this script is being run 
@@ -543,11 +577,13 @@ def get_local_xapi_session():
     session.login_with_password("", "")
     return session
 
+
 def get_remote_xapi_session(creds):
     """Return a remote xapi session based on creds"""
     session = XenAPI.Session("http://%s" % creds['host'])
     session.login_with_password(creds['user'], creds['pass'])
     return session
+
 
 def get_pool_master(session):
     """Returns the reference to host which is currently master
@@ -556,23 +592,29 @@ def get_pool_master(session):
     host_ref = session.xenapi.pool.get_master(pool_ref)
     return host_ref
 
+
 def _find_control_domain(session, host_ref):
     vm_recs = session.xenapi.VM.get_all_records()
     for vm_ref, vm_rec in vm_recs.iteritems():
         if vm_rec['is_control_domain'] and vm_rec['resident_on'] == host_ref:
             return vm_ref
-    raise Exception("Unexpected error. Cannot find control domain on host %s" % host_ref)
+    raise Exception(
+        "Unexpected error. Cannot find control domain on host %s" % host_ref)
+
 
 def get_master_control_domain(session):
     master_ref = get_pool_master(session)
     return _find_control_domain(session, master_ref)
 
+
 def get_slave_control_domain(session):
     slave_refs = get_pool_slaves(session)
     if not slave_refs:
-        raise Exception("Error: the test kit requires a pool of at least 2 hosts.")
-    #Only care about the first slave reference
+        raise Exception(
+            "Error: the test kit requires a pool of at least 2 hosts.")
+    # Only care about the first slave reference
     return _find_control_domain(session, slave_refs[0])
+
 
 def set_reboot_flag(tc_info=None, flag_loc=REBOOT_FLAG_FILE):
     """Set an OS flag (i.e. touch a file) for when we're about to reboot.
@@ -583,6 +625,7 @@ def set_reboot_flag(tc_info=None, flag_loc=REBOOT_FLAG_FILE):
     if tc_info:
         ffile.write(str(tc_info))
     ffile.close()
+
 
 def get_reboot_flag(flag=REBOOT_FLAG_FILE):
     """Return a dictionary that contains information of when reboot was
@@ -602,6 +645,7 @@ def get_reboot_flag(flag=REBOOT_FLAG_FILE):
     else:
         return None
 
+
 def get_reboot_flag_timestamp(flag=REBOOT_FLAG_FILE):
     """Finding when reboot was initialised."""
     if os.path.exists(flag):
@@ -609,30 +653,33 @@ def get_reboot_flag_timestamp(flag=REBOOT_FLAG_FILE):
         return datetime(*(time.strptime(time_str, "%a %b %d %H:%M:%S %Y")[0:6]))
     return None
 
+
 def clear_reboot_flag(flag=REBOOT_FLAG_FILE):
     if os.path.exists(flag):
         os.remove(flag)
-            
+
+
 def host_reboot(session, running_tc_info=None):
     log.debug("Attempting to reboot the host")
-    #Cleanup all the running vms
+    # Cleanup all the running vms
     pool_wide_cleanup(session)
 
     master = get_pool_master(session)
-    
+
     hosts = session.xenapi.host.get_all()
     for host in hosts:
         session.xenapi.host.disable(host)
         if host != master:
             session.xenapi.host.reboot(host)
-            
+
     set_reboot_flag(running_tc_info)
 
     session.xenapi.host.reboot(master)
     log.debug("Rebooted master")
     sys.exit(REBOOT_ERROR_CODE)
 
-def host_crash(session, do_cleanup = False):
+
+def host_crash(session, do_cleanup=False):
     """ Force crash master. The host will be rebooted once it crashes."""
     if do_cleanup:
         pool_wide_cleanup(session)
@@ -645,8 +692,10 @@ def host_crash(session, do_cleanup = False):
     log.debug("Crashing host: %s" % host)
     call_ack_plugin(session, 'force_crash_host')
 
-    # Once it is successful, host will be crashed hence code should not reach here.
+    # Once it is successful, host will be crashed hence code should not reach
+    # here.
     raise Exception("Failed to crash host.")
+
 
 def retrieve_latest_crashdump(session, host=None, fromxapi=False):
     """Retrieve latest one from crashdump list"""
@@ -654,36 +703,39 @@ def retrieve_latest_crashdump(session, host=None, fromxapi=False):
     if not cds:
         return None
 
-    latest = sorted(cds, key = lambda cd: cd['timestamp'], reverse=True)[0]
+    latest = sorted(cds, key=lambda cd: cd['timestamp'], reverse=True)[0]
 
     log.debug("Latest crashdump: %s" % latest)
 
     return latest
 
+
 def retrieve_crashdumps(session, host=None, fromxapi=False):
     """Retrive all list of crashdump of master."""
     if not host:
         host = get_pool_master(session)
-    cds = call_ack_plugin(session, 'retrieve_crashdumps', {'host': host, 'from_xapi': str(fromxapi)})
+    cds = call_ack_plugin(session, 'retrieve_crashdumps', {
+                          'host': host, 'from_xapi': str(fromxapi)})
     for cd in cds:
         cd['size'] = int(cd['size'])
         ts = cd['timestamp']
         if fromxapi:
-            cd['timestamp'] = datetime(int(ts[:4]), # year
-                            int(ts[4:6]),   # month
-                            int(ts[6:8]),   # day
-                            int(ts[9:11]),  # hour
-                            int(ts[12:14]), # minute
-                            int(ts[15:17])) # second
+            cd['timestamp'] = datetime(int(ts[:4]),  # year
+                                       int(ts[4:6]),   # month
+                                       int(ts[6:8]),   # day
+                                       int(ts[9:11]),  # hour
+                                       int(ts[12:14]),  # minute
+                                       int(ts[15:17]))  # second
         else:
-            cd['timestamp'] = datetime(int(ts[:4]), # year
-                            int(ts[4:6]),   # month
-                            int(ts[6:8]),   # day
-                            int(ts[9:11]),  # hour
-                            int(ts[11:13]), # minute
-                            int(ts[13:15])) # second
+            cd['timestamp'] = datetime(int(ts[:4]),  # year
+                                       int(ts[4:6]),   # month
+                                       int(ts[6:8]),   # day
+                                       int(ts[9:11]),  # hour
+                                       int(ts[11:13]),  # minute
+                                       int(ts[13:15]))  # second
     log.debug("Retained Crashdumps: %s" % str(cds))
     return cds
+
 
 def print_test_results(tracker):
     """Method for pretty printing results"""
@@ -701,7 +753,8 @@ def print_test_results(tracker):
                 if test.has_key('exception'):
                     print "Exceptions:", test['exception'], "\n"
                 else:
-                    print 
+                    print
+
 
 def get_pool_slaves(session):
     """Returns a list of references for each host in a pool
@@ -714,12 +767,13 @@ def get_pool_slaves(session):
             slaves.append(host)
     return slaves
 
+
 def get_xenserver_version(session):
     """Return the XenServer version (using the master host)"""
     master_ref = get_pool_master(session)
     software = session.xenapi.host.get_software_version(master_ref)
     xs_str = software['xs:main']
-    #parse string of the form: 'XenServer Pack, version 6.0.0, build 50762c'
+    # parse string of the form: 'XenServer Pack, version 6.0.0, build 50762c'
     arr = xs_str.split(',')
     for item in arr:
         if item.strip().startswith('version'):
@@ -727,12 +781,13 @@ def get_xenserver_version(session):
             return version
     raise Exception("XenServer Version could not be detected! %s" % xs_str)
 
+
 def get_xcp_version(session):
     """Return the XCP version (using the master host)"""
     master_ref = get_pool_master(session)
     software = session.xenapi.host.get_software_version(master_ref)
     xs_str = software['xcp:main']
-    #parse string of the form: 'XenServer Pack, version 6.0.0, build 50762c'
+    # parse string of the form: 'XenServer Pack, version 6.0.0, build 50762c'
     arr = xs_str.split(',')
     for item in arr:
         if item.strip().startswith('version'):
@@ -740,9 +795,11 @@ def get_xcp_version(session):
             return version
     raise Exception("XCP Version could not be detected! %s" % xs_str)
 
+
 def get_kernel_version(session):
     """Return kernel version using uname"""
     return call_ack_plugin(session, 'get_kernel_version')
+
 
 def eval_expr(expr, val):
     """Evaluate an expression against a provided value.
@@ -750,7 +807,7 @@ def eval_expr(expr, val):
     log.debug("Eval Expr: %s %s" % (expr, val))
     arr = expr.split()
     if len(arr) > 3:
-        raise Exception("Could not evaluate expression. " + 
+        raise Exception("Could not evaluate expression. " +
                         "Format is incorrect: %s" % expr)
 
     condition = arr[0]
@@ -769,8 +826,9 @@ def eval_expr(expr, val):
     if condition == "<=":
         return val <= test_val
 
-    raise Exception("Specified condition is not yet supported for comparison: %s" % 
+    raise Exception("Specified condition is not yet supported for comparison: %s" %
                     condition)
+
 
 def append_result_node(dom, parent_node, result):
     """parent_node is an xml node to be appended to, result
@@ -781,6 +839,7 @@ def append_result_node(dom, parent_node, result):
         k = dom.createElement(key)
         element.appendChild(k)
         k.appendChild(dom.createTextNode(result[key]))
+
 
 def make_local_call(call):
     """Function wrapper for making a simple call to shell"""
@@ -793,6 +852,7 @@ def make_local_call(call):
         log.debug("ERR: %s, %s" % (stdout, stderr))
         sys.exit()
 
+
 def save_bugtool():
     """Saves a bugtool and returns the name"""
     print "Collecting a bugtool report:"
@@ -801,6 +861,7 @@ def save_bugtool():
     where = info.find('/var/opt/xen/bug-report')
     return ((info[where:]).split())[0]
 
+
 def compress_output_files(mylist):
     """Compress all output files to bz2 and return the name"""
     print "Compressing output files..."""
@@ -808,6 +869,7 @@ def compress_output_files(mylist):
     for myfile in mylist:
         tar.add(myfile)
     tar.close()
+
 
 def output_test_results(tracker):
     """Outputs an xml results doc and creates a xen-bugtool,
@@ -825,16 +887,18 @@ def output_test_results(tracker):
     myfile.close()
     bugtool = save_bugtool()
     compress_output_files([xml_file_name, bugtool])
-                       
+
+
 def create_network(session, name_label, description, other_config):
     """Method for creating a XAPI network"""
-    net_ref = session.xenapi.network.create({'name_label':name_label,
-                                   'description':description,
-                                   'other_config':other_config})
+    net_ref = session.xenapi.network.create({'name_label': name_label,
+                                             'description': description,
+                                             'other_config': other_config})
     oc = session.xenapi.network.get_other_config(net_ref)
     oc[FOR_CLEANUP] = "true"
     session.xenapi.network.set_other_config(net_ref, oc)
     return net_ref
+
 
 def create_nic_bond(session, network, nics, mac='', mode='balance-slb'):
     """Creates a bond of type mode between two PIFs and returns 
@@ -848,6 +912,7 @@ def create_nic_bond(session, network, nics, mac='', mode='balance-slb'):
     oc[FOR_CLEANUP] = "true"
     session.xenapi.Bond.set_other_config(net_ref, oc)
     return net_ref
+
 
 def get_pifs_by_device(session, device, hosts=[]):
     """Using device name (e.g. eth0) return a reference to the PIF that 
@@ -866,8 +931,9 @@ def get_pifs_by_device(session, device, hosts=[]):
     if len(results) > 0:
         return results
     raise TestCaseError("""No Ethernet device named %s 
-                        can be found on host(s) %s""" % 
+                        can be found on host(s) %s""" %
                         (device, hosts))
+
 
 def get_network_by_device(session, device):
     pifs = get_pifs_by_device(session, device)
@@ -879,11 +945,12 @@ def get_network_by_device(session, device):
     assert(len(network_refs) == 1)
     return network_refs.pop()
 
+
 def get_physical_devices_by_network(session, network):
     """Taking a network, enumerate the list of physical devices attached 
     to each component PIF. This may require some unwrapping (e.g. bonds)
     to determine all the consituent physical PIFs."""
-   
+
     def get_physical_pifs(session, pifs):
         res = []
         for pif in pifs:
@@ -896,10 +963,13 @@ def get_physical_devices_by_network(session, network):
                     res = res + get_physical_pifs(session, bond_pifs)
             elif pif_rec['VLAN_master_of'] != 'OpaqueRef:NULL':
                 log.debug("VLAN PIF found: %s." % pif_rec)
-                vlan_obj = session.xenapi.VLAN.get_record(pif_rec['VLAN_master_of'])
-                res = res + get_physical_pifs(session, [vlan_obj['tagged_PIF']])
+                vlan_obj = session.xenapi.VLAN.get_record(
+                    pif_rec['VLAN_master_of'])
+                res = res + \
+                    get_physical_pifs(session, [vlan_obj['tagged_PIF']])
             else:
-                raise Exception("Error: %s is not physical, bond or VLAN" % pif_rec)
+                raise Exception(
+                    "Error: %s is not physical, bond or VLAN" % pif_rec)
         return res
 
     pifs = session.xenapi.network.get_PIFs(network)
@@ -917,7 +987,7 @@ def get_physical_devices_by_network(session, network):
     if len(devices) > 1:
         log.debug("More than one device for network %s: %s" % (network,
                                                                devices))
-    return devices 
+    return devices
 
 
 def filter_pif_devices(session, devices):
@@ -925,7 +995,7 @@ def filter_pif_devices(session, devices):
     defined by a user."""
     res = []
     management_device = get_pool_management_device(session)
-    
+
     for device in devices:
         if device != management_device:
             res.append(device)
@@ -935,11 +1005,14 @@ def filter_pif_devices(session, devices):
                                 interfaces from those supplied""")
     return res
 
+
 def get_equivalent_devices(session, device):
     devices = get_master_network_devices(session)
-    ifaces = [dev['Kernel_name'] for dev in devices if device['PCI_id'] == dev['PCI_id']]
+    ifaces = [dev['Kernel_name']
+              for dev in devices if device['PCI_id'] == dev['PCI_id']]
     log.debug("Equivalent devices for %s: %s" % (device, ifaces))
     return ifaces
+
 
 def get_management_network(session):
     networks = session.xenapi.network.get_all()
@@ -951,6 +1024,7 @@ def get_management_network(session):
 
     raise Exception("ERROR: No management network found!")
 
+
 def get_management_interface(session, host):
     # this is for backward compatibility.
     # host.get_management_interface is added in XenServer 6.1
@@ -961,11 +1035,13 @@ def get_management_interface(session, host):
 
     raise Exception("ERROR: No management interface found!")
 
+
 def create_vlan(session, pif_ref, network_ref, vlan_id):
     """Create a VLAN PIF from an existing physical PIF on the specified
     network"""
     log.debug("About to create_vlan")
     return session.xenapi.VLAN.create(pif_ref, str(vlan_id), network_ref)
+
 
 def get_droid_templates(session, brand=DROID_TEMPLATE_TAG):
     """Return the reference to the template for the 
@@ -978,33 +1054,37 @@ def get_droid_templates(session, brand=DROID_TEMPLATE_TAG):
             droid_vms.append(vm)
     return droid_vms
 
+
 def brand_vm(session, vm_ref, brand=DROID_VM):
     """Take a VM, or template and brand it with a key in other_config"""
     oc = session.xenapi.VM.get_other_config(vm_ref)
     oc[brand] = 'True'
     session.xenapi.VM.set_other_config(vm_ref, oc)
 
+
 def convert_to_template(session, vm_ref):
     """Convert a VM to a template"""
     return session.xenapi.VM.set_is_a_template(vm_ref, True)
 
+
 def create_vif(session, device, network, vm, mac=''):
     """Method for creating a XAPI Virtual Interface"""
     return session.xenapi.VIF.create({'device': device,
-                               'network': network,
-                               'VM': vm,
-                               'MAC': mac,
-                               'MTU': '1504',
-                               'other_config': {},
-                               'qos_algorithm_type': '',
-                               'qos_algorithm_params': {}})
+                                      'network': network,
+                                      'VM': vm,
+                                      'MAC': mac,
+                                      'MTU': '1504',
+                                      'other_config': {},
+                                      'qos_algorithm_type': '',
+                                      'qos_algorithm_params': {}})
+
 
 def setup_vm_on_network(session, vm_ref, network_ref, iface='eth0', wipe=True):
     """Remove VIFs plugged into a VM, and create a new
     VIF and plug it in for a particular network"""
-    
+
     if wipe:
-        #1. Remove all existings VIFs
+        # 1. Remove all existings VIFs
         vif_refs = session.xenapi.VM.get_VIFs(vm_ref)
         log.debug("Existing VIFs %s" % vif_refs)
 
@@ -1019,21 +1099,22 @@ def setup_vm_on_network(session, vm_ref, network_ref, iface='eth0', wipe=True):
 
     log.debug("Create a new VIF for VM")
     log.debug("Network ref = %s" % network_ref)
-    #2. Create a new VIF attached to the specified network reference
-    vif_ref = create_vif(session, iface.replace('eth',''),
-                        network_ref, vm_ref, mac=generate_mac())
-    
+    # 2. Create a new VIF attached to the specified network reference
+    vif_ref = create_vif(session, iface.replace('eth', ''),
+                         network_ref, vm_ref, mac=generate_mac())
+
     if session.xenapi.VM.get_power_state(vm_ref) == "Running":
         log.debug("Plug VIF %s" % vif_ref)
         session.xenapi.VIF.plug(vif_ref)
 
     return vif_ref
-   
+
 
 def make_vm_noninteractive(session, vm_ref):
     """Set PV args to ensure the Demo VM boots up automatically,
     without requring a user to add a password"""
     session.xenapi.VM.set_PV_args(vm_ref, 'noninteractive')
+
 
 def xenstore_read(path):
     """Uses the local xenstore utility to read a specified path"""
@@ -1045,9 +1126,11 @@ def xenstore_read(path):
     else:
         raise TestCaseError(stderr)
 
+
 def should_timeout(start, timeout):
     """Method for evaluating whether a time limit has been met"""
     return time.time() - start > float(timeout)
+
 
 def _get_control_domain_ip(session, vm_ref, device='xenbr0'):
     """Return the IP address for a specified control domain"""
@@ -1057,6 +1140,7 @@ def _get_control_domain_ip(session, vm_ref, device='xenbr0'):
     host_ref = session.xenapi.VM.get_resident_on(vm_ref)
     return call_ack_plugin(session, 'get_local_device_ip', {'device': device},
                            host_ref)
+
 
 def wait_for_ip(session, vm_ref, device, timeout=300):
     """Wait for an IP address to be returned (until a given timeout)"""
@@ -1071,11 +1155,13 @@ def wait_for_ip(session, vm_ref, device, timeout=300):
 
     if session.xenapi.VM.get_is_control_domain(vm_ref):
         ipaddr = _get_control_domain_ip(session, vm_ref, device)
-        log.debug("Control domain %s has IP %s on device %s" % (vm_ref, ipaddr, device))
+        log.debug("Control domain %s has IP %s on device %s" %
+                  (vm_ref, ipaddr, device))
         return ipaddr
 
     if not device.startswith('eth'):
-        raise Exception("Invalid device specified, it should be in the format 'ethX'")
+        raise Exception(
+            "Invalid device specified, it should be in the format 'ethX'")
 
     start = time.time()
 
@@ -1099,6 +1185,7 @@ def wait_for_ip(session, vm_ref, device, timeout=300):
     raise Exception("""Timeout has been exceeded waiting for IP
                      address of VM to be returned %s """ % str(timeout))
 
+
 def wait_for_all_ips(session, vm_ref, timeout=300):
     """wait for all interface to have IPs"""
 
@@ -1107,16 +1194,19 @@ def wait_for_all_ips(session, vm_ref, timeout=300):
         host_ref = session.xenapi.VM.resident_on(vm_ref)
         for pif in session.xenapi.PIF.get_all():
             if host_ref == session.xenapi.PIF.get_host(pif):
-                device = 'eth' + str(session.xenapi.PIF.get_device(pif)).strip()
+                device = 'eth' + \
+                    str(session.xenapi.PIF.get_device(pif)).strip()
                 ips[device] = _get_control_domain_ip(session, vm_ref, device)
 
     else:
         for vif in session.xenapi.VIF.get_all():
             if vm_ref == session.xenapi.VIF.get_VM(vif):
-                device = 'eth' + str(session.xenapi.VIF.get_device(vif)).strip()
+                device = 'eth' + \
+                    str(session.xenapi.VIF.get_device(vif)).strip()
                 ips[device] = wait_for_ip(session, vm_ref, device, timeout)
 
     return ips
+
 
 def _is_link_up(statedict):
     """Evaluate current operstate, carrier and link from dict."""
@@ -1125,37 +1215,40 @@ def _is_link_up(statedict):
         return True
     return False
 
+
 def wait_for_linkstate(session, device, state, host_ref=None, timeout=60):
     """Wait for interface to be a given state."""
 
-    args = { 'device': device }
+    args = {'device': device}
     start = time.time()
     while not should_timeout(start, timeout):
-        results = call_ack_plugin(session, 'get_local_device_linkstate', args, host_ref)
+        results = call_ack_plugin(
+            session, 'get_local_device_linkstate', args, host_ref)
         cur_state = results[0]
-        log.debug("Current linkstate of %s on host %s is %s." % (device, host_ref, cur_state))
+        log.debug("Current linkstate of %s on host %s is %s." %
+                  (device, host_ref, cur_state))
         if state.lower() == 'up' and _is_link_up(cur_state):
             return
         if state.lower() == 'down' and not _is_link_up(cur_state):
             return
-            
+
         time.sleep(2)
 
     raise Exception("Timeout has been exceeded waiting for %s on %s changed to %s"
-                     % (device, host_ref, state))
+                    % (device, host_ref, state))
 
 
 def get_vm_ips(session, vm_ref):
     guest_metrics_ref = session.xenapi.VM.get_guest_metrics(vm_ref)
     if guest_metrics_ref == "OpaqueRef:NULL":
-        return {} 
+        return {}
     networks = session.xenapi.VM_guest_metrics.get_networks(guest_metrics_ref)
     res = {}
     for k, v in networks.iteritems():
         if k.endswith('ip'):
             res["eth%s" % (k.replace('/ip', ''))] = v
     return res
-    
+
 
 def ping(vm_ip, dst_vm_ip, interface, packet_size=1400,
          count=20, username="root", password=DEFAULT_PASSWORD):
@@ -1171,15 +1264,16 @@ def ping(vm_ip, dst_vm_ip, interface, packet_size=1400,
         cmd_str = "ping -I %s -s %d -c %d %s" % \
             (interface, packet_size, count, dst_vm_ip)
     log.debug("Ping: %s" % cmd_str)
-    result = ssh_command(vm_ip, username, password, cmd_str, attempts=10).split('\n')
+    result = ssh_command(vm_ip, username, password,
+                         cmd_str, attempts=10).split('\n')
     log.debug("Results= %s" % result)
     for line in result:
         log.debug("SSH Line: %s" % line)
         if 'transmitted' in line:
             return line
     raise TestCaseError("""Error: Unexpected response 
-                       from ping, to transmission statistics: %s""" \
-                            % result)
+                       from ping, to transmission statistics: %s"""
+                        % result)
 
 
 def ssh_command(ip, username, password, cmd_str, dbg_str=None, attempts=10):
@@ -1218,7 +1312,7 @@ def add_network_interface(vm_ip, interface_name, interface_ip,
         cmd = "ifconfig %s %s netmask %s up" % \
             (interface_name, interface_ip, interface_netmask)
 
-    ssh_command(vm_ip, username, password, cmd, cmd, attempts=10)    
+    ssh_command(vm_ip, username, password, cmd, cmd, attempts=10)
 
 
 def plug_pif(session, pif):
@@ -1264,22 +1358,24 @@ def destroy_vm(session, vm_ref, timeout=60):
     while power_state != 'Halted' or len(cur_oper) > 0:
         log.debug("VM is %s with %s in action." % (power_state, str(cur_oper)))
         if should_timeout(start, timeout):
-            raise Exception("Failed to stop VM or VM is not in right state. (VM: %s, power_state: %s)" % (vm_ref, power_state))
+            raise Exception("Failed to stop VM or VM is not in right state. (VM: %s, power_state: %s)" % (
+                vm_ref, power_state))
         log.debug("Trying shutting down VM: %s" % vm_ref)
         # Due to timing issue this may fail as it tries to shutdown halted VM.
         try:
             session.xenapi.VM.hard_shutdown(vm_ref)
         except Exception, e:
             log.error(str(e))
-            log.debug("Failed to hard shutdown VM. Trying again in a few seconds.")
+            log.debug(
+                "Failed to hard shutdown VM. Trying again in a few seconds.")
         time.sleep(5)
 
         power_state = session.xenapi.VM.get_power_state(vm_ref)
         cur_oper = session.xenapi.VM.get_current_operations(vm_ref)
-        
+
     log.debug("VM %s is ready to be removed." % vm_ref)
 
-    #Check that the VDI is not in-use
+    # Check that the VDI is not in-use
     vbd_refs = session.xenapi.VM.get_VBDs(vm_ref)
     for vbd_ref in vbd_refs:
         vdi_ref = session.xenapi.VBD.get_VDI(vbd_ref)
@@ -1292,16 +1388,18 @@ def destroy_vm(session, vm_ref, timeout=60):
                 ops_list = session.xenapi.VDI.get_allowed_operations(vdi_ref)
                 if should_timeout(start, timeout):
                     raise Exception("Cannot destroy VDI: VDI is still active")
-            #If the VDI is free, try to destroy it. Should pass the exception catch if it is a NULL VDI reference.
+            # If the VDI is free, try to destroy it. Should pass the exception
+            # catch if it is a NULL VDI reference.
             session.xenapi.VDI.destroy(vdi_ref)
         except XenAPI.Failure, exn:
             if exn.details[0] == 'HANDLE_INVALID':
                 pass
             else:
                 raise exn
-    #Finally, destroy the VM
+    # Finally, destroy the VM
     log.debug("Destroying VM %s" % vm_ref)
     session.xenapi.VM.destroy(vm_ref)
+
 
 def pool_wide_cleanup(session, tag=FOR_CLEANUP):
     """This function will look for all the object with a given tag,
@@ -1318,7 +1416,7 @@ def host_cleanup(session, host):
     cur_route_table = route.RouteTable(routes)
 
     oc = session.xenapi.host.get_other_config(host)
-    
+
     # Load in default routes
     default_route_key = 'default_routes'
     default_route_list = []
@@ -1327,14 +1425,14 @@ def host_cleanup(session, host):
         for rec in default_routes:
             route_obj = route.Route(**rec)
             default_route_list.append(route_obj)
-    
-    default_route_table = route.RouteTable(default_route_list) 
+
+    default_route_table = route.RouteTable(default_route_list)
     missing_routes = default_route_table.get_missing(cur_route_table)
 
     dom0_ref = _find_control_domain(session, host)
     for missing_route in missing_routes:
-        log.debug("Missing route: %s. Attempting to add to host %s" % \
-                    (missing_route.get_record(), host))
+        log.debug("Missing route: %s. Attempting to add to host %s" %
+                  (missing_route.get_record(), host))
 
         args = {'vm_ref': dom0_ref,
                 'dest_ip': missing_route.get_dest(),
@@ -1344,12 +1442,14 @@ def host_cleanup(session, host):
         call_ack_plugin(session, 'add_route', args, host)
 
     log.debug("host cleanup is complete.")
-    
+
+
 def pool_wide_host_cleanup(session):
     hosts = session.xenapi.host.get_all()
 
     for host in hosts:
         host_cleanup(session, host)
+
 
 def pool_wide_vm_cleanup(session, tag):
     """Searches for VMs with a cleanup tag, and destroys"""
@@ -1372,7 +1472,7 @@ def pool_wide_vm_cleanup(session, tag):
                                         'dest_ip': v,
                                     })
                     keys_to_clean.append(k)
-            
+
             if keys_to_clean:
                 for key in keys_to_clean:
                     del oc[key]
@@ -1403,8 +1503,8 @@ def pool_wide_network_cleanup(session, tag):
             if oc.pop(tag, None):
                 log.debug("Pif to cleanup: %s from host %s" % (pif, host))
                 call_ack_plugin(session, 'flush_local_device',
-                    {'device': session.xenapi.PIF.get_device(pif)},
-                    host = host)
+                                {'device': session.xenapi.PIF.get_device(pif)},
+                                host=host)
                 session.xenapi.PIF.set_other_config(pif, oc)
 
 
@@ -1417,21 +1517,24 @@ def get_pool_management_device(session):
             device_name = session.xenapi.PIF.get_device(pif)
             if device:
                 if device_name != device:
-                    raise TestCaseError("""Error: Different device names are marked as management. Check that there are no residual bonds.""")
+                    raise TestCaseError(
+                        """Error: Different device names are marked as management. Check that there are no residual bonds.""")
             else:
                 device = device_name
     return device
-        
+
+
 def get_module_names(name_filter):
     """Returns a list of modules which can be seen in the callers scope,
     filtering their names by the given filter."""
     modules = []
-    #Get all of the modules names currently in scope
+    # Get all of the modules names currently in scope
     for module in sys.modules.keys():
-        #Apply filter
+        # Apply filter
         if name_filter in module:
             modules.append(module)
     return modules
+
 
 def change_vm_power_state(session, vm_ref):
     """Toggles VM powerstate between halted and running"""
@@ -1445,22 +1548,25 @@ def change_vm_power_state(session, vm_ref):
         log.debug("%s is booting" % vm_ref)
         session.xenapi.VM.start(vm_ref, False, False)
 
+
 def arg_encode(string):
     """Encode a string for sending over XML-RPC to plugin"""
     return string.replace('/', '&#47;').replace('.', '&#46;')
 
+
 def droid_template_import(session, host_ref, sr_uuid):
     """Import the droid template into the specified SR"""
-    #Note, the filename should be fully specified.
+    # Note, the filename should be fully specified.
     args = {'sr_uuid': sr_uuid}
-    return call_ack_plugin(session, 'droid_template_import', args, host=host_ref)  
+    return call_ack_plugin(session, 'droid_template_import', args, host=host_ref)
+
 
 def get_default_sr(session):
     """Returns the SR reference marked as default in the pool"""
     pool_ref = session.xenapi.pool.get_all()[0]
     sr_ref = session.xenapi.pool.get_default_SR(pool_ref)
     try:
-        #A call to check 'freshness' of default SR reference
+        # A call to check 'freshness' of default SR reference
         log.debug("Default SR: %s" % session.xenapi.SR.get_name_label(sr_ref))
         return sr_ref
     except XenAPI.Failure, exn:
@@ -1468,7 +1574,8 @@ def get_default_sr(session):
             raise Exception("Pool is not configured to have shared storage!")
         else:
             raise exn
-        
+
+
 def get_local_sr(session, host):
     """Returns the ref object the local SR on the master host"""
     all_pbds = session.xenapi.PBD.get_all_records()
@@ -1479,33 +1586,35 @@ def get_local_sr(session, host):
                 if 'Local storage' in sr_rec['name_label']:
                     if pbd_rec['SR'] in sr_ref:
                         return sr_ref
-    raise Exception("No local SR attached to the master host")    
+    raise Exception("No local SR attached to the master host")
+
 
 def assert_sr_connected(session, sr_ref, host_ref):
     """Assert that a given SR is connected to a host"""
     pbds = session.xenapi.SR.get_PBDs(sr_ref)
     for pbd in pbds:
         if session.xenapi.PBD.get_host(pbd) == host_ref:
-            log.debug("SR %s connected to host %s" % (session.xenapi.SR.get_uuid(sr_ref), session.xenapi.host.get_name_label(host_ref)))
+            log.debug("SR %s connected to host %s" % (session.xenapi.SR.get_uuid(
+                sr_ref), session.xenapi.host.get_name_label(host_ref)))
             return True
     return False
-    
 
-def find_storage_for_host(session, host_ref, exclude_types=['iso','udev']):
+
+def find_storage_for_host(session, host_ref, exclude_types=['iso', 'udev']):
     """Given a host reference, return available storage"""
     srs = session.xenapi.SR.get_all()
 
     # Find relevent SRs based on whether they're connected to host
-    rel_srs = [sr for sr in srs \
-                     if assert_sr_connected(session, sr, host_ref) and
-                     session.xenapi.SR.get_type(sr) not in exclude_types]
+    rel_srs = [sr for sr in srs
+               if assert_sr_connected(session, sr, host_ref) and
+               session.xenapi.SR.get_type(sr) not in exclude_types]
 
     log.debug("Available SRs for host '%s': '%s'" % (host_ref, rel_srs))
 
     log.debug("Host: %s" % session.xenapi.host.get_name_label(host_ref))
     for sr in rel_srs:
         log.debug("SR: %s" % session.xenapi.SR.get_name_label(sr))
-    return rel_srs                             
+    return rel_srs
 
 
 def import_droid_vm(session, host_ref, creds=None, loc=DROID_VM_LOC):
@@ -1513,12 +1622,13 @@ def import_droid_vm(session, host_ref, creds=None, loc=DROID_VM_LOC):
     sr_refs = find_storage_for_host(session, host_ref)
 
     if not sr_refs:
-        raise Exception("Error: could not find any available SRs for host '%s'" % host_ref)
+        raise Exception(
+            "Error: could not find any available SRs for host '%s'" % host_ref)
 
     sr_ref = sr_refs.pop()
-    log.debug("Importing droid VM to %s for use on host %s" % \
-                (session.xenapi.SR.get_name_label(sr_ref),
-                 session.xenapi.host.get_name_label(host_ref)))
+    log.debug("Importing droid VM to %s for use on host %s" %
+              (session.xenapi.SR.get_name_label(sr_ref),
+               session.xenapi.host.get_name_label(host_ref)))
 
     sr_uuid = session.xenapi.SR.get_uuid(sr_ref)
     vm_uuid = droid_template_import(session, host_ref, sr_uuid)
@@ -1535,17 +1645,19 @@ def find_droid_templates(session):
     vms = session.xenapi.VM.get_all_records()
     for ref, rec in vms.iteritems():
         if DROID_TEMPLATE_TAG in rec['other_config'] \
-                             and rec['is_a_template']: 
-            refs.append(ref)                             
-    
+                and rec['is_a_template']:
+            refs.append(ref)
+
     log.debug("find_droid_templates: found refs: '%s'" % refs)
 
     return refs
+
 
 def get_vm_vdis(session, vm_ref):
     vbds = session.xenapi.VM.get_VBDs(vm_ref)
     vdis = [session.xenapi.VBD.get_VDI(vbd) for vbd in vbds]
     return [vdi for vdi in vdis if vdi != "OpaqueRef:NULL"]
+
 
 def assert_can_boot_here(session, vm_ref, host_ref):
     vdis = get_vm_vdis(session, vm_ref)
@@ -1566,16 +1678,17 @@ def prepare_droid_vm(session, host_ref, creds=None):
     on the host - if it does, it prepares it"""
     log.debug("About to prepare droid vm for host %s" % host_ref)
 
-    templates = [template for template in find_droid_templates(session) \
-          if assert_can_boot_here(session, template, host_ref)]
-    
+    templates = [template for template in find_droid_templates(session)
+                 if assert_can_boot_here(session, template, host_ref)]
+
     if templates:
         # Any of the templates will do
         return templates.pop()
     else:
         log.debug("No droid vm template exists - import one")
-        #Else - if no templates exist
+        # Else - if no templates exist
         return import_droid_vm(session, host_ref, creds)
+
 
 def run_xapi_async_tasks(session, funcs, timeout=300):
     """Execute a list of async functions, only returning when
@@ -1593,7 +1706,7 @@ def run_xapi_async_tasks(session, funcs, timeout=300):
 
     results = []
     while task_refs:
-        idx, ref = task_refs.pop(0) #take the first item off
+        idx, ref = task_refs.pop(0)  # take the first item off
         log.debug("Current Task: %s" % ref)
         status = session.xenapi.task.get_status(ref)
         if status == "success":
@@ -1602,38 +1715,40 @@ def run_xapi_async_tasks(session, funcs, timeout=300):
 
             log.debug("Result = %s" % result)
             if result.startswith('<value>'):
-                results.append((idx,result.split('value')[1].strip('</>')))
+                results.append((idx, result.split('value')[1].strip('</>')))
             else:
-                #Some Async calls have no return value
-                results.append((idx,result))
+                # Some Async calls have no return value
+                results.append((idx, result))
         elif status == "failure":
-            #The task has failed, and the error should be propogated upwards.
-            raise Exception("Async call failed with error: %s" % session.xenapi.task.get_error_info(ref))
+            # The task has failed, and the error should be propogated upwards.
+            raise Exception("Async call failed with error: %s" %
+                            session.xenapi.task.get_error_info(ref))
         else:
             log.debug("Task Status: %s" % status)
-            #task has not finished, so re-attach to list
+            # task has not finished, so re-attach to list
             task_refs.append((idx, ref))
 
         if should_timeout(start, timeout):
             # Change to TimeoutFunctionException to work-around CA-146164.
             # To avoid applying hotfixes, keeping this work-around.
-            # raise Exception("Async calls took too long to complete!" + 
+            # raise Exception("Async calls took too long to complete!" +
             raise TimeoutFunctionException("Async calls took too long to complete!" +
-                            "Perhaps, the operation has stalled? %d" % timeout)
+                                           "Perhaps, the operation has stalled? %d" % timeout)
         time.sleep(1)
 
     # Sort the results in order of index
     results = sorted(results, key=lambda tup: tup[0])
     return [res for (_, res) in results]
 
+
 def deploy_count_droid_vms_on_host(session, host_ref, network_refs, vm_count, sms=None, sr_ref=None):
     """Deploy vm_count VMs on the host_ref host. Required 
     to define the network, optionally the SR"""
 
     log.debug("Creating required VM(s)")
-        
+
     droid_template_ref = prepare_droid_vm(session, host_ref)
-    
+
     task_list = []
     vm_ref_list = []
     for i in range(vm_count):
@@ -1644,29 +1759,34 @@ def deploy_count_droid_vms_on_host(session, host_ref, network_refs, vm_count, sm
         brand_vm(session, vm_ref, FOR_CLEANUP)
         session.xenapi.VM.set_is_a_template(vm_ref, False)
         make_vm_noninteractive(session, vm_ref)
-        
+
         x = 0
         for network_ref in network_refs:
-            log.debug("Setup vm (%s) eth%d on network (%s)" % (vm_ref, x, network_ref))
-            setup_vm_on_network(session, vm_ref, network_ref, 'eth%d' % x, wipe=(x==0))
+            log.debug("Setup vm (%s) eth%d on network (%s)" %
+                      (vm_ref, x, network_ref))
+            setup_vm_on_network(session, vm_ref, network_ref,
+                                'eth%d' % x, wipe=(x == 0))
 
             if sms and network_ref in sms.keys() and sms[network_ref]:
                 static_manager = sms[network_ref]
                 ip = static_manager.get_ip()
-                log.debug("IP: %s Netmask: %s Gateway: %s" % (ip.addr, ip.netmask, ip.gateway))
-                droid_set_static(session, vm_ref, 'ipv4', 'eth%d' % x, ip.addr, ip.netmask, ip.gateway)
+                log.debug("IP: %s Netmask: %s Gateway: %s" %
+                          (ip.addr, ip.netmask, ip.gateway))
+                droid_set_static(session, vm_ref, 'ipv4', 'eth%d' %
+                                 x, ip.addr, ip.netmask, ip.gateway)
             # Increment interface counter
             x = x + 1
 
         # Add VM to startup list
         log.debug("Adding VM to startup list: %s" % vm_ref)
-        task_list.append(lambda x=vm_ref: session.xenapi.Async.VM.start_on(x, host_ref, False, False))
+        task_list.append(lambda x=vm_ref: session.xenapi.Async.VM.start_on(
+            x, host_ref, False, False))
         vm_ref_list.append(vm_ref)
 
     # Starting VMs async
     log.debug("Starting up all VMs")
     run_xapi_async_tasks(session, task_list)
-    
+
     # Wait for IPs to be returned
     log.debug("Wait for IPs...")
     for vm_ref in vm_ref_list:
@@ -1675,8 +1795,9 @@ def deploy_count_droid_vms_on_host(session, host_ref, network_refs, vm_count, sm
 
     # Check the VMs are in the 'Running' state.
     wait_for_vms(session, vm_ref_list, XAPI_RUNNING_STATE)
-    
+
     return vm_ref_list
+
 
 def wait_for_vms(session, vm_refs, power_state, timeout=60):
     """Wait for XAPI to mark each VM in the list as 'Running'"""
@@ -1696,46 +1817,49 @@ def wait_for_vms(session, vm_refs, power_state, timeout=60):
         for vm in vms:
             log.debug("VM not in '%s' state. Instead in '%s' state." %
                       (power_state, session.xenapi.VM.get_power_state(vm)))
-        
+
         # We should raise an exception.
-        raise Exception("VMs (%s) were not moved to the '%s' state in the provided timeout ('%d')" % (vms, power_state, timeout))
-        
+        raise Exception("VMs (%s) were not moved to the '%s' state in the provided timeout ('%d')" % (
+            vms, power_state, timeout))
 
 
 def deploy_slave_droid_vm(session, network_refs, sms=None):
     """Deploy a single VM on the slave host. This might be useful for
     tests between Dom0 and a VM. The Dom0 of the master is used for running
     commands, whilst the VM on the slave is used as a target"""
-    
+
     host_slave_refs = get_pool_slaves(session)
 
     if len(host_slave_refs) == 0:
-        raise Exception("ERROR: There appears to only be one host in this pool." + 
+        raise Exception("ERROR: There appears to only be one host in this pool." +
                         " Please add another host and retry.")
 
-    #Pick the first slave reference    
+    # Pick the first slave reference
     host_slave_ref = host_slave_refs[0]
-            
+
     log.debug("Creating required VM")
-        
+
     droid_template_ref = prepare_droid_vm(session, host_slave_ref)
     vm_ref = session.xenapi.VM.clone(droid_template_ref, 'Droid 1')
-    
+
     brand_vm(session, vm_ref, FOR_CLEANUP)
     session.xenapi.VM.set_is_a_template(vm_ref, False)
     make_vm_noninteractive(session, vm_ref)
 
     i = 0
     for network_ref in network_refs:
-        log.debug("Setting interface up for eth%d (network_ref = %s)" % (i, network_ref))
-        setup_vm_on_network(session, vm_ref, network_ref, 'eth%d' % i, wipe=(i==0))
+        log.debug("Setting interface up for eth%d (network_ref = %s)" %
+                  (i, network_ref))
+        setup_vm_on_network(session, vm_ref, network_ref,
+                            'eth%d' % i, wipe=(i == 0))
 
-    
         if sms and network_ref in sms.keys() and sms[network_ref]:
             static_manager = sms[network_ref]
             ip = static_manager.get_ip()
-            log.debug("IP: %s Netmask: %s Gateway: %s" % (ip.addr, ip.netmask, ip.gateway))
-            droid_set_static(session, vm_ref, 'ipv4', 'eth%d' % i, ip.addr, ip.netmask, ip.gateway)
+            log.debug("IP: %s Netmask: %s Gateway: %s" %
+                      (ip.addr, ip.netmask, ip.gateway))
+            droid_set_static(session, vm_ref, 'ipv4', 'eth%d' %
+                             i, ip.addr, ip.netmask, ip.gateway)
 
         # Increment the counter
         i = i + 1
@@ -1743,8 +1867,8 @@ def deploy_slave_droid_vm(session, network_refs, sms=None):
     log.debug("Starting required VM %s" % vm_ref)
     session.xenapi.VM.start_on(vm_ref, host_slave_ref, False, False)
 
-    #Temp fix for establishing that a VM has fully booted before
-    #continuing with executing commands against it.
+    # Temp fix for establishing that a VM has fully booted before
+    # continuing with executing commands against it.
     wait_for_all_ips(session, vm_ref)
 
     return vm_ref
@@ -1753,65 +1877,69 @@ def deploy_slave_droid_vm(session, network_refs, sms=None):
 def deploy_two_droid_vms(session, network_refs, sms=None):
     """A utility method for setting up two VMs, one on the primary host,
     and one on a slave host"""
-    
+
     host_master_ref = get_pool_master(session)
     host_slave_refs = get_pool_slaves(session)
 
     if len(host_slave_refs) == 0:
-        raise Exception("ERROR: There appears to only be one host in this pool." + 
+        raise Exception("ERROR: There appears to only be one host in this pool." +
                         " Please add another host and retry.")
-    
+
     host_slave_ref = host_slave_refs[0]
-            
+
     log.debug("Creating required VMs")
-        
+
     # Get template references
     dmt_ref = prepare_droid_vm(session, host_master_ref)
     dst_ref = prepare_droid_vm(session, host_slave_ref)
 
     results = run_xapi_async_tasks(session,
-              [lambda: session.xenapi.Async.VM.clone(dmt_ref,
-                                                     'Droid 1'),
-               lambda: session.xenapi.Async.VM.clone(dst_ref,
-                                                     'Droid 2')])
+                                   [lambda: session.xenapi.Async.VM.clone(dmt_ref,
+                                                                          'Droid 1'),
+                                    lambda: session.xenapi.Async.VM.clone(dst_ref,
+                                                                          'Droid 2')])
 
     if len(results) != 2:
-        raise Exception("Expect to clone 2 vms - only got %d results" \
-                            % len(results))
+        raise Exception("Expect to clone 2 vms - only got %d results"
+                        % len(results))
 
-    vm1_ref = results[0] #Droid 1
-    vm2_ref = results[1] #Droid 2
-            
+    vm1_ref = results[0]  # Droid 1
+    vm2_ref = results[1]  # Droid 2
+
     brand_vm(session, vm1_ref, FOR_CLEANUP)
     brand_vm(session, vm2_ref, FOR_CLEANUP)
 
     session.xenapi.VM.set_is_a_template(vm1_ref, False)
     session.xenapi.VM.set_is_a_template(vm2_ref, False)
-            
+
     make_vm_noninteractive(session, vm1_ref)
     make_vm_noninteractive(session, vm2_ref)
-            
+
     log.debug("Setup vms on network")
     i = 0
     for network_ref in network_refs:
         log.debug("Setting interfaces up for eth%d" % i)
         # Note: only remove all existing networks on first run.
-        setup_vm_on_network(session, vm1_ref, network_ref, 'eth%d' % i, wipe=(i==0))
-        setup_vm_on_network(session, vm2_ref, network_ref, 'eth%d' % i, wipe=(i==0))
+        setup_vm_on_network(session, vm1_ref, network_ref,
+                            'eth%d' % i, wipe=(i == 0))
+        setup_vm_on_network(session, vm2_ref, network_ref,
+                            'eth%d' % i, wipe=(i == 0))
 
         log.debug("Static Manager Recs: %s" % sms)
         if sms and network_ref in sms.keys() and sms[network_ref]:
             static_manager = sms[network_ref]
             ip1 = static_manager.get_ip()
             ip2 = static_manager.get_ip()
-            log.debug("1) IP: %s Netmask: %s Gateway: %s" % (ip1.addr, ip1.netmask, ip1.gateway))
-            log.debug("2) IP: %s Netmask: %s Gateway: %s" % (ip2.addr, ip2.netmask, ip2.gateway))
+            log.debug("1) IP: %s Netmask: %s Gateway: %s" %
+                      (ip1.addr, ip1.netmask, ip1.gateway))
+            log.debug("2) IP: %s Netmask: %s Gateway: %s" %
+                      (ip2.addr, ip2.netmask, ip2.gateway))
 
-            droid_set_static(session, vm1_ref, 'ipv4', 'eth%d' % i, 
+            droid_set_static(session, vm1_ref, 'ipv4', 'eth%d' % i,
                              ip1.addr, ip1.netmask, ip1.gateway)
-            droid_set_static(session, vm2_ref, 'ipv4', 'eth%d' % i, 
+            droid_set_static(session, vm2_ref, 'ipv4', 'eth%d' % i,
                              ip2.addr, ip2.netmask, ip2.gateway)
-        
+
         # Increment the counter
         i = i + 1
 
@@ -1819,23 +1947,23 @@ def deploy_two_droid_vms(session, network_refs, sms=None):
     try:
         # Temporary setting time out to 3 mins to work around CA-146164.
         # The fix requires hotfixes, hence keeping this work-around.
-        run_xapi_async_tasks(session, \
-            [lambda: session.xenapi.Async.VM.start_on(vm1_ref,
-                                                     host_master_ref,
-                                                     False, False),
-            lambda: session.xenapi.Async.VM.start_on(vm2_ref,
-                                                     host_slave_ref,
-                                                     False, False)],
-            180)
-    
+        run_xapi_async_tasks(session,
+                             [lambda: session.xenapi.Async.VM.start_on(vm1_ref,
+                                                                       host_master_ref,
+                                                                       False, False),
+                              lambda: session.xenapi.Async.VM.start_on(vm2_ref,
+                                                                       host_slave_ref,
+                                                                       False, False)],
+                             180)
+
     except TimeoutFunctionException, e:
         # Temporary ignore time out to start VM.
         # If VM failed to start, test will fail while checking IPs.
         log.debug("Timed out while starting VMs: %s" % e)
         log.debug("Async call timed out but VM may started properly. tests go on.")
 
-    #Temp fix for establishing that a VM has fully booted before
-    #continuing with executing commands against it.
+    # Temp fix for establishing that a VM has fully booted before
+    # continuing with executing commands against it.
     log.debug("Wait for IPs...")
     wait_for_all_ips(session, vm1_ref)
     wait_for_all_ips(session, vm2_ref)
@@ -1844,16 +1972,17 @@ def deploy_two_droid_vms(session, network_refs, sms=None):
     # Make plugin calls
     for vm_ref in [vm1_ref, vm2_ref]:
         # Install SSH Keys for Plugin operations
-        call_ack_plugin(session, 'inject_ssh_key', 
-                                {'vm_ref': vm_ref,
+        call_ack_plugin(session, 'inject_ssh_key',
+                        {'vm_ref': vm_ref,
                                  'username': 'root',
                                  'password': DEFAULT_PASSWORD})
-                                                    
-        # Ensure that we make sure the switch accesses IP addresses by 
-        # their own interfaces (avoid interface forwarding).        
+
+        # Ensure that we make sure the switch accesses IP addresses by
+        # their own interfaces (avoid interface forwarding).
         call_ack_plugin(session, 'reset_arp', {'vm_ref': vm_ref})
 
     return vm1_ref, vm2_ref
+
 
 def droid_set_static(session, vm_ref, protocol, iface, ip, netmask, gw):
     args = {'vm_uuid': session.xenapi.VM.get_uuid(vm_ref),
@@ -1863,6 +1992,7 @@ def droid_set_static(session, vm_ref, protocol, iface, ip, netmask, gw):
             'netmask': netmask,
             'gateway': gw}
     return call_ack_plugin(session, 'droid_set_static_conf', args)
+
 
 def get_non_management_pifs(session):
     """Return a list of pif refs for non management devices"""
@@ -1876,7 +2006,8 @@ def get_non_management_pifs(session):
         raise Exception("No management PIFs were found!")
 
     return results
-    
+
+
 class TimeoutFunction:
     """Wrapper class for providing a timemout for 
     the execution of a function"""
@@ -1899,11 +2030,12 @@ class TimeoutFunction:
             signal.signal(signal.SIGALRM, old)
         return result
 
+
 def json_loads(json_data):
     def process_dict_keys(d):
         new_d = {}
         for key in d.iterkeys():
-            new_key = str(key.replace(" ","_"))
+            new_key = str(key.replace(" ", "_"))
             new_d[new_key] = d[key]
         return new_d
 
@@ -1922,16 +2054,17 @@ def json_loads(json_data):
     data = json.loads(json_data, object_hook=process_values)
     return [data] if isinstance(data, dict) else data
 
+
 def call_ack_plugin(session, method, args={}, host=None):
     if not host:
         host = get_pool_master(session)
-    log.debug("About to call plugin '%s' on host '%s' with args '%s'" % \
-                (method, host, args))
+    log.debug("About to call plugin '%s' on host '%s' with args '%s'" %
+              (method, host, args))
 
     res = session.xenapi.host.call_plugin(host,
-                                           'autocertkit',
-                                           method,
-                                           args)
+                                          'autocertkit',
+                                          method,
+                                          args)
     log.debug("Plugin Output: %s" % res)
     return json_loads(res)
 
@@ -1942,20 +2075,22 @@ def get_hw_offloads(session, device):
 
     if call_ack_plugin(session, 'get_kernel_version').startswith('2.6'):
         res = call_ack_plugin(session, 'get_hw_offloads_from_core',
-                              {'eth_dev':device})
+                              {'eth_dev': device})
     else:
         res = call_ack_plugin(session, 'get_hw_offloads',
-                              {'eth_dev':device})
+                              {'eth_dev': device})
 
     return res[0]
 
+
 def get_dom0_iface_info(session, host_ref, device):
     res = call_ack_plugin(session, 'get_local_device_info',
-                                        {'device': device},
-                                        host=host_ref)
+                          {'device': device},
+                          host=host_ref)
 
     device_dict = res[0]
     return Iface(device_dict)
+
 
 def get_vm_device_mac(session, vm_ref, device):
     """For a specified VM, obtain the MAC address of the specified dev"""
@@ -1971,17 +2106,19 @@ def get_vm_device_mac(session, vm_ref, device):
         vifs = session.xenapi.VM.get_VIFs(vm_ref)
         for vif in vifs:
             vif_rec = session.xenapi.VIF.get_record(vif)
-            if vif_rec['device'] == device.replace('eth',''):
+            if vif_rec['device'] == device.replace('eth', ''):
                 return vif_rec['MAC']
         raise Exception("Error: could not find device '%s' for VM '%s'" %
                         (device, vm_ref))
 
-def get_iface_statistics(session, vm_ref, iface): 
+
+def get_iface_statistics(session, vm_ref, iface):
     res = call_ack_plugin(session, 'get_iface_stats',
-                                        {'iface':iface,
-                                        'vm_ref': vm_ref})
+                          {'iface': iface,
+                           'vm_ref': vm_ref})
     stats_dict = res[0]
     return IfaceStats(iface, stats_dict)
+
 
 def set_hw_offload(session, device, offload, state):
     """Call the a XAPI plugin on the pool master to set
@@ -1991,12 +2128,14 @@ def set_hw_offload(session, device, offload, state):
                            {'eth_dev': device, 'offload': offload,
                             'state': state})
 
+
 def parse_csv_list(string):
     arr = string.split(',')
     res = []
     for item in arr:
         res.append(item.strip())
     return res
+
 
 def set_nic_device_status(session, interface, status, creds=None):
     """Function to set an ifconfig ethX interface up or down"""
@@ -2015,19 +2154,24 @@ def set_nic_device_status(session, interface, status, creds=None):
 
     return res
 
+
 class TestThread(threading.Thread):
     """Threading class that runs a function"""
+
     def __init__(self, function):
         self.function = function
         threading.Thread.__init__(self)
+
     def run(self):
         self.function()
+
 
 def create_test_thread(function):
     """Function for creating and starting a number of threads"""
     thread = TestThread(function)
     thread.start()
     return thread
+
 
 def check_test_thread_status(threads):
     """Util function to check if test threads are still active,
@@ -2040,16 +2184,19 @@ def check_test_thread_status(threads):
             return True
     return False
 
+
 def get_master_network_devices(session):
     devices = call_ack_plugin(session, 'get_network_devices')
     log.debug("Network Devices found on machine: '%s'" % devices)
     return devices
+
 
 def get_local_storage_info(session):
     """Returns info about the local storage devices"""
     devices = call_ack_plugin(session, 'get_local_storage_devices')
     log.debug("Local Storage Devices found on machine: '%s'" % devices)
     return devices
+
 
 def get_xs_info(session):
     """Returns a limited subset of info about the XenServer version"""
@@ -2061,6 +2208,7 @@ def get_xs_info(session):
             'xapi': info['xapi'],
             'date': info['date']}
 
+
 def _get_type_and_value(entry):
     """Parse dmidecode entry and return key/value pair"""
     r = {}
@@ -2069,7 +2217,8 @@ def _get_type_and_value(entry):
         if len(s) != 2:
             continue
         r[s[0].strip()] = s[1].strip()
-    return r   
+    return r
+
 
 def get_system_info():
     """Returns some information of system and bios."""
@@ -2113,6 +2262,7 @@ def get_system_info():
 
     return rec
 
+
 def get_master_ifaces(session):
     devices = get_master_network_devices(session)
     ifaces = []
@@ -2120,10 +2270,12 @@ def get_master_ifaces(session):
         ifaces.append(device['Kernel_name'])
     return ifaces
 
+
 def set_dict_attributes(node, config):
     """Take a dict object, and set xmlnode attributes accordingly"""
     for k, v in config.iteritems():
         node.setAttribute(str(k), str(v))
+
 
 def get_xml_attributes(node):
     """Return the xml attributes of a node as a dictionary object"""
@@ -2132,6 +2284,7 @@ def get_xml_attributes(node):
         attr[k] = v
     return attr
 
+
 def get_text_from_node_list(nlist, tag):
     for node in nlist:
         if node.nodeType == node.ELEMENT_NODE and node.tagName == tag:
@@ -2139,36 +2292,41 @@ def get_text_from_node_list(nlist, tag):
                 if subnode.nodeType == node.TEXT_NODE:
                     return subnode.data.strip()
 
+
 def to_bool(string):
     """Convert string value of true/false to bool"""
     return string.upper() == "TRUE"
+
 
 def get_value(rec, key, default=""):
     if key in rec.keys():
         return rec[key]
     else:
         return default
-    
+
+
 def print_documentation(object_name):
     print "--------- %s ---------" % bold(object_name)
     classes = enumerate_test_classes()
     for test_class_name, test_class in classes:
         arr = (object_name).split('.')
         if test_class_name == object_name:
-            #get the class info
+            # get the class info
             print format(test_class.__doc__)
             print "%s: %s" % (bold('Prereqs'), test_class.required_config)
             sys.exit(0)
         elif len(arr) == 3 and ".".join(arr[:2]) == test_class_name:
-            #get the method info
+            # get the method info
             print format(getattr(test_class, arr[2]).__doc__)
             sys.exit(0)
 
     print "The test name specified (%s) was incorrect. Please specify the full test name." % object_name
     sys.exit(0)
 
+
 def bold(str):
     return "\033[1m%s\033[0;0m" % str
+
 
 def format(str):
     """Format string to flow continuiously (without indents that have been inserted
@@ -2177,27 +2335,32 @@ def format(str):
     arr = [item.strip() for item in arr]
     return " ".join(arr)
 
+
 def enumerate_test_classes():
     import test_generators
-    tg = test_generators.TestGenerator('nonexistent_session', {}, 'nonexistent')
+    tg = test_generators.TestGenerator(
+        'nonexistent_session', {}, 'nonexistent')
     return tg.get_test_classes()
+
 
 def read_valid_lines(filename):
     """Utility function for returning alist of uncommented lines (as indicated by '#')."""
     comment_symbols = ['#']
     fh = open(filename, 'r')
     res = [line for line in [line.strip() for line in fh.readlines()]
-        if len(line) > 0 and line[0] not in comment_symbols]
+           if len(line) > 0 and line[0] not in comment_symbols]
     fh.close()
     return res
+
 
 def set_network_mtu(session, network_ref, MTU):
     """Utility function for setting a network's MTU. MTU should be a string"""
     session.xenapi.network.set_MTU(network_ref, str(MTU))
-    pifs = session.xenapi.network.get_PIFs(network_ref)        
+    pifs = session.xenapi.network.get_PIFs(network_ref)
     for pif in pifs:
         unplug_pif(session, pif)
         plug_pif(session, pif)
+
 
 def intersection(lista, listb):
     """Return the intersection between two lists. Note,
@@ -2205,13 +2368,14 @@ def intersection(lista, listb):
     we merely check if item in lista, is in listb."""
     return [item for item in lista if item in listb]
 
+
 def get_cpu_id(cpu_des):
     """Return an ID for a CPU based on their extended CPU
     string as returned via CPUID."""
 
     if not cpu_des:
         return "Unkown CPU ID"
-    
+
     if 'intel' in cpu_des.lower():
         # Discard processor frequency
         tmp = cpu_des.split('@')[0]
@@ -2219,7 +2383,7 @@ def get_cpu_id(cpu_des):
         return ' '.join(arr).replace('(R)', '')
     elif 'amd' in cpu_des.lower():
         return cpu_des.replace('(tm)', '')
-        
+
 
 def wait_for_hosts(session, timeout=300):
     """Wait until both hosts are up and live."""
@@ -2243,18 +2407,22 @@ def wait_for_hosts(session, timeout=300):
                     dom0 = _find_control_domain(session, host)
                     _get_control_domain_ip(session, dom0, dev)
                 except:
-                    log.debug("Host %s(%s) is up but not live yet." % (hostname, hostuuid))
+                    log.debug("Host %s(%s) is up but not live yet." %
+                              (hostname, hostuuid))
                     break
                 else:
-                    log.debug("Host %s(%s) is up and live." % (hostname, hostuuid))
+                    log.debug("Host %s(%s) is up and live." %
+                              (hostname, hostuuid))
             else:
-                log.debug("Host %s(%s) is not fully up yet." % (hostname, hostuuid))
+                log.debug("Host %s(%s) is not fully up yet." %
+                          (hostname, hostuuid))
                 break
         else:
             return
         time.sleep(2)
 
     raise Exception("Hosts(%s) failed to come back online" % hosts)
+
 
 def get_ack_version(session, host):
     """Return the version string corresponding to the cert kit on a particular host"""
@@ -2263,42 +2431,49 @@ def get_ack_version(session, host):
     if key in sw.keys():
         return sw[key]
 
+
 def combine_recs(rec1, rec2):
     """Utility function for combining two records into one."""
     rec = dict(rec1)
     for k, v in rec2.iteritems():
         if k in rec.keys():
-            raise Exception("Cannot combine these recs, and keys overalp (%s)" % k)        
+            raise Exception(
+                "Cannot combine these recs, and keys overalp (%s)" % k)
         rec[k] = v
 
     return rec
+
 
 def check_vm_ping_response(session, vm_ref, interface='eth0', count=3, timeout=300):
     """Function to run a simple check that a VM responds to a ping from the XenServer"""
     # Get VM IP and start timeout
     vm_ip = wait_for_ip(session, vm_ref, interface)
     start = time.time()
-    
+
     # Loop while waiting for an ICMP response
     while not should_timeout(start, timeout):
-    
+
         call = ["ping", vm_ip, "-c %s" % count]
-        
+
         # Make the local shell call
-        log.debug("Checking for ping response from VM %s on interface %s at %s" % (vm_ref, interface, vm_ip))
+        log.debug("Checking for ping response from VM %s on interface %s at %s" % (
+            vm_ref, interface, vm_ip))
         process = subprocess.Popen(call, stdout=subprocess.PIPE)
         stdout, stderr = process.communicate()
         response = str(stdout).strip()
-        
-        # Check for no packet loss. Note the space before '0%', this is required.
+
+        # Check for no packet loss. Note the space before '0%', this is
+        # required.
         if " 0% packet loss" in response:
             log.debug("Ping response received from %s" % vm_ip)
             return response
-    
+
         log.debug("No ping response")
         time.sleep(3)
-    
-    raise Exception("VM %s interface %s could not be reached in the given timeout" % (vm_ref, interface))
+
+    raise Exception("VM %s interface %s could not be reached in the given timeout" % (
+        vm_ref, interface))
+
 
 def valid_ping_response(ping_response, max_loss=0):
 
@@ -2314,11 +2489,13 @@ def valid_ping_response(ping_response, max_loss=0):
         return loss <= max_loss
     else:
         # We did not match the ping output, therefore we cannot
-        # validate the response.    
+        # validate the response.
         return False
 
 
 dmidecode_output = None
+
+
 @log_exceptions
 def get_dmidecode_output():
     """ Build dmidecode information data structure from output of dmidecode. """
@@ -2335,6 +2512,7 @@ def get_dmidecode_output():
                 buf += line + os.linesep
     return dmidecode_output
 
+
 @log_exceptions
 def search_dmidecode(keyword):
     """ Search ttype or busid from ds """
@@ -2345,4 +2523,3 @@ def search_dmidecode(keyword):
             found.append(info)
 
     return found
-

--- a/mk/acktools-setup.py
+++ b/mk/acktools-setup.py
@@ -7,6 +7,4 @@ setup(name='AutoCertKit',
       author='Citrix System Inc.',
       url='http://github.com/xenserver/auto-cert-kit',
       packages=['acktools', 'acktools.net'],
-     )
-
-
+      )

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -3,31 +3,31 @@
 # Copyright (c) Citrix Systems Inc.
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, 
-# with or without modification, are permitted provided 
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
 # that the following conditions are met:
 #
-# *   Redistributions of source code must retain the above 
-#     copyright notice, this list of conditions and the 
+# *   Redistributions of source code must retain the above
+#     copyright notice, this list of conditions and the
 #     following disclaimer.
-# *   Redistributions in binary form must reproduce the above 
-#     copyright notice, this list of conditions and the 
-#     following disclaimer in the documentation and/or other 
+# *   Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the
+#     following disclaimer in the documentation and/or other
 #     materials provided with the distribution.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
 #
@@ -38,7 +38,8 @@ import XenAPI
 import XenAPIPlugin
 import subprocess
 import xmlrpclib
-import os, sys
+import os
+import sys
 import shutil
 import time
 import logging
@@ -92,11 +93,13 @@ PS = "/bin/ps"
 UNAME = "/bin/uname"
 PGREP = "/usr/bin/pgrep"
 
-##### Logging setup
+# Logging setup
 
 LOG_LOC = '/var/log/auto-cert-kit-plugin.log'
 
 log = None
+
+
 def configure_logging(name):
     global log
     if log:
@@ -106,21 +109,27 @@ def configure_logging(name):
 
 configure_logging('autocertkit')
 
-##### Exceptions
+# Exceptions
+
 
 class PluginError(Exception):
     """Base Exception class for all plugin errors."""
+
     def __init__(self, *args):
         Exception.__init__(self, *args)
+
 
 class ArgumentError(PluginError):
     """Raised when required arguments are missing, argument values are invalid,
     or incompatible arguments are given.
     """
+
     def __init__(self, *args):
         PluginError.__init__(self, *args)
 
-##### Exception Decorator
+# Exception Decorator
+
+
 def log_exceptions(func):
     def decorated(*args, **kwargs):
         try:
@@ -129,18 +138,21 @@ def log_exceptions(func):
             log.error('%s: XenAPI.Failure: %s', func.__name__, str(e))
             raise
         except PluginError, e:
-            log.error('%s: %s: %s', func.__name__, e.__class__.__name__, str(e))
+            log.error('%s: %s: %s', func.__name__,
+                      e.__class__.__name__, str(e))
             raise
         except Exception, e:
-            log.error('%s: %s: %s', func.__name__, e.__class__.__name__, str(e))
+            log.error('%s: %s: %s', func.__name__,
+                      e.__class__.__name__, str(e))
             raise
     return decorated
 #############################
 
+
 class Iface(object):
     """Class representing an ethernet interface"""
 
-    required_keys = ["ip","mask","mac"]
+    required_keys = ["ip", "mask", "mac"]
 
     def __init__(self, rec):
         self.validate_rec(rec)
@@ -158,14 +170,15 @@ class Iface(object):
         for key in self.required_keys:
             rec[key] = getattr(self, key)
         return rec
-        
 
-##### Argument validation
+
+# Argument validation
 
 ARGUMENT_PATTERN = re.compile(r'^[a-zA-Z0-9_:\.\-,]+$')
-#Base64 allows the '=' symbol for padding - which is disallowed in shell-safe regex
-#Extra symbols: '=', '/', '+'
+# Base64 allows the '=' symbol for padding - which is disallowed in shell-safe regex
+# Extra symbols: '=', '/', '+'
 ARGUMENT_PATTERN_BASE64 = re.compile(r'^[a-zA-Z0-9_:\.\-\=\/\+,]+$')
+
 
 def validate_exists(args, key, default=None, required=True):
     """Validates that a string argument to a RPC method call is given, and
@@ -176,24 +189,30 @@ def validate_exists(args, key, default=None, required=True):
     """
     if key in args:
         if len(args[key]) == 0:
-            raise ArgumentError('Argument %r value %r is too short.' % (key, args[key]))
+            raise ArgumentError(
+                'Argument %r value %r is too short.' % (key, args[key]))
         if key == "vhd_blocks":
             if not ARGUMENT_PATTERN_BASE64.match(args[key]):
-                raise ArgumentError('Argument %r value %r contains invalid characters for Base64.' % (key, args[key]))
+                raise ArgumentError(
+                    'Argument %r value %r contains invalid characters for Base64.' % (key, args[key]))
         elif not ARGUMENT_PATTERN.match(args[key]):
-            raise ArgumentError('Argument %r value %r contains invalid characters.' % (key, args[key]))
+            raise ArgumentError(
+                'Argument %r value %r contains invalid characters.' % (key, args[key]))
         if args[key][0] == '-':
-            raise ArgumentError('Argument %r value %r starts with a hyphen.' % (key, args[key]))
+            raise ArgumentError(
+                'Argument %r value %r starts with a hyphen.' % (key, args[key]))
         return args[key]
     elif not required or not default:
         return default
     else:
         raise ArgumentError('Argument %s is required.' % key)
 
+
 @log_exceptions
 def get_from_xensource_inventory(key):
     if os.path.isfile(XS_INVENTORY_PATH) == False:
-        raise XenAPI.Failure(['NO_INVENTORY_FILE', "The XenSource Inventory file is missing."])
+        raise XenAPI.Failure(
+            ['NO_INVENTORY_FILE', "The XenSource Inventory file is missing."])
     fh = open(XS_INVENTORY_PATH, "r")
     data = fh.readlines()
     fh.close()
@@ -233,15 +252,15 @@ OFFLOAD_CODES = {'udp-fragmentation-offload': 'ufo',
                  'ntuple-filters': 'ntuple',
                  'receive-hashing': 'rxhash'}
 OFFLOAD_FLAGS_OFFSET = {'sg': 1,
-                 'tso': 1<<16,
-                 'ufo': 1<<17,
-                 'gso': 1<<11,
-                 'gro': 1<<14,
-                 'lro': 1<<15,
-                 'rxvlan': 1<<8,
-                 'txvlan': 1<<7,
-                 'ntuple': 1<<27,
-                 'rxhash': 1<<28}
+                        'tso': 1 << 16,
+                        'ufo': 1 << 17,
+                        'gso': 1 << 11,
+                        'gro': 1 << 14,
+                        'lro': 1 << 15,
+                        'rxvlan': 1 << 8,
+                        'txvlan': 1 << 7,
+                        'ntuple': 1 << 27,
+                        'rxhash': 1 << 28}
 
 
 ############# SSH KEY SETUP ##########################
@@ -270,21 +289,23 @@ def ssh_command(ip, username, password, cmd_str, dbg_str=None, attempts=10):
 
     raise PluginError("An unkown error has occured!")
 
+
 def install_ssh_key(session, vm_ref, username, password):
     """Install Dom0 public key in droid VM"""
     setup_public_ssh_key()
     vm_ip = wait_for_ip(session, vm_ref, 'eth0')
 
-    fh = open(SSH_PUBLIC_KEY,'r')
+    fh = open(SSH_PUBLIC_KEY, 'r')
     public_key = fh.read()
     fh.close()
 
     # Remove any host key previously installed for the specified IP address
-    call = ["/bin/sed","-i","/%s/d" % vm_ip, SSH_HOST_KEYS]
+    call = ["/bin/sed", "-i", "/%s/d" % vm_ip, SSH_HOST_KEYS]
     make_local_call(call)
 
     cmd1 = ["mkdir", "-p", "/root/.ssh"]
-    cmd2 = ["echo", "\"%s\"" % public_key.strip(), ">>", "/root/.ssh/authorized_keys"]
+    cmd2 = ["echo", "\"%s\"" %
+            public_key.strip(), ">>", "/root/.ssh/authorized_keys"]
     cmd_str = "%s; %s" % (" ".join(cmd1), " ".join(cmd2))
 
     log.debug("Install SSH key command string: %s" % cmd_str)
@@ -296,13 +317,16 @@ def install_ssh_key(session, vm_ref, username, password):
 
     return True
 
+
 def setup_public_ssh_key():
     if not os.path.exists(SSH_PUBLIC_KEY):
-        call = ['/usr/bin/ssh-keygen', '-f', SSH_PUBLIC_KEY.replace('.pub',''),
+        call = ['/usr/bin/ssh-keygen', '-f', SSH_PUBLIC_KEY.replace('.pub', ''),
                 '-N', '']
         make_local_call(call)
 
 ######################################################
+
+
 @log_exceptions
 def inject_ssh_key(session, args):
     """Inject Dom0's public SSH key into a guest VM"""
@@ -318,7 +342,7 @@ def inject_ssh_key(session, args):
 @log_exceptions
 def wait_for_ip(session, vm_ref, device, timeout=60):
     """Wait for an IP address to be returned (until a given timeout)"""
-    
+
     xs_data = session.xenapi.VM.get_xenstore_data(vm_ref)
     log.debug("xenstore data: %s" % xs_data)
     key = "vm-data/control/%s/ip" % device
@@ -327,9 +351,9 @@ def wait_for_ip(session, vm_ref, device, timeout=60):
                                                     vm_ref))
         return xs_data[key]
 
-
     if not device.startswith('eth'):
-        raise PluginError("Invalid device specified, it should be in the format 'ethX'")
+        raise PluginError(
+            "Invalid device specified, it should be in the format 'ethX'")
 
     start = time.time()
 
@@ -341,7 +365,7 @@ def wait_for_ip(session, vm_ref, device, timeout=60):
     while not should_timeout(start, timeout):
         log.debug("Trying to retrieve VM IP address - Attempt %d" % i)
         ips = get_vm_ips(session, vm_ref)
-        log.debug("VM %s has these %s IPs" % (vm_ref,ips))
+        log.debug("VM %s has these %s IPs" % (vm_ref, ips))
 
         for k, v in ips.iteritems():
             if k == device:
@@ -353,14 +377,16 @@ def wait_for_ip(session, vm_ref, device, timeout=60):
     raise PluginError("""Timeout has been exceeded waiting for IP
                      address of VM to be returned %s """ % str(timeout))
 
+
 def get_vm_ips(session, vm_ref):
     guest_metrics_ref = session.xenapi.VM.get_guest_metrics(vm_ref)
     networks = session.xenapi.VM_guest_metrics.get_networks(guest_metrics_ref)
     res = {}
     for k, v in networks.iteritems():
         if k.endswith('ip'):
-            res["eth%s" % (k.replace('/ip',''))] = v
+            res["eth%s" % (k.replace('/ip', ''))] = v
     return res
+
 
 @log_exceptions
 def get_local_device_linkstate(session, arg):
@@ -388,7 +414,8 @@ def get_local_device_linkstate(session, arg):
         res['link'] = 'unknown'
 
     return json_dumps(res)
-    
+
+
 def save_bugtool():
     """Saves a bugtool and returns the name"""
     log.debug("Collecting a bugtool report")
@@ -399,12 +426,14 @@ def save_bugtool():
     log.debug("Bugtool saved: %s" % bugtool_loc)
     return bugtool_loc
 
+
 def run_ack_logrotate(session, args):
     """Run logrotate for ACK logs"""
     ack_logrotate_dconf = '/etc/logrotate.d/autocertkit'
     global log
-    
-    # This method should not log before logrotate execution to avoid os file handle error
+
+    # This method should not log before logrotate execution to avoid os file
+    # handle error
     try:
         shutil.copyfile(LOGROTATE_CONF_LOC, ack_logrotate_dconf)
         call = ['/usr/sbin/logrotate', '-f', ack_logrotate_dconf]
@@ -425,12 +454,13 @@ def run_ack_logrotate(session, args):
 
 ############### IPERF Setup #########################
 
+
 def install_iperf(session, vm_ref, username, password):
     """Install iperf rpm on a droid vm"""
     ip_address = wait_for_ip(session, vm_ref, 'eth0')
-    call = ['/usr/bin/scp', 
+    call = ['/usr/bin/scp',
             "-o", "StrictHostKeyChecking=no",
-            "/opt/xensource/packages/files/auto-cert-kit/%s" % IPERF_RPM, 
+            "/opt/xensource/packages/files/auto-cert-kit/%s" % IPERF_RPM,
             'root@%s:' % ip_address]
     log.debug(call)
     make_local_call(call)
@@ -438,13 +468,15 @@ def install_iperf(session, vm_ref, username, password):
     log.debug(cmd_str)
     ssh_command(ip_address, username, password, cmd_str)
 
+
 def make_local_call(call, logging=True):
     """Function wrapper for making a simple call to shell"""
     if logging:
         log.debug("make_local_call: %s" % (" ".join(call)))
     process = subprocess.Popen(call, stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()
-    res = {"returncode": process.returncode, "stdout": str(stdout).strip(), "stderr": str(stderr).strip()}
+    res = {"returncode": process.returncode, "stdout": str(
+        stdout).strip(), "stderr": str(stderr).strip()}
     if res["returncode"] != 0:
         msg = "ERR: Could not make local call %s" % ' '.join(call)
         if logging:
@@ -452,6 +484,7 @@ def make_local_call(call, logging=True):
             log.debug("stdout: %s" % str(stdout))
             log.debug("stderr: %s" % str(stderr))
     return res
+
 
 def validate_xml_key(key):
     """Check that a key will be acceptable for an XML attribute
@@ -465,8 +498,10 @@ def validate_xml_key(key):
     else:
         return False
 
+
 def json_dumps(data):
     return json.dumps(data, indent=2, separators=(',', ': '))
+
 
 @log_exceptions
 def deploy_iperf(session, args):
@@ -489,14 +524,16 @@ def deploy_iperf(session, args):
                 install_iperf(session, vm_ref, username, password)
                 break
             except:
-                log.debug("Exception raised attempting to deploy iperf. Attempt %d" % i)
-                time.sleep(8) #Sleep 8 seconds
-                i = i + 1 #Increment counter
+                log.debug(
+                    "Exception raised attempting to deploy iperf. Attempt %d" % i)
+                time.sleep(8)  # Sleep 8 seconds
+                i = i + 1  # Increment counter
                 if i == limit:
                     raise PluginError("Plugin Error: Cannot deploy Iperf")
-                
+
     log.debug("iPerf installation completed")
     return json_dumps("OK")
+
 
 def get_pci_id(bus_id):
     """Return the PCI id for a specified bus location"""
@@ -507,13 +544,14 @@ def get_pci_id(bus_id):
     except Exception, e:
         log.debug("Exception: %s" % str(e))
 
+
 def get_pci_description(bus_id):
-    """Return the PCI description for a specified bus location"""    
+    """Return the PCI description for a specified bus location"""
     log.debug("Getting decription for PCI device at bus id: %s" % bus_id)
     devices = PCIDevices()
 
     if bus_id not in devices.devs.keys():
-        #Biosdevname returns shortened Bus IDs, so check that.
+        # Biosdevname returns shortened Bus IDs, so check that.
         # i.e. instead of '0000:02:00.1' --> '02:00.1'
         # remove front 5 characters.
         short_bus_id = bus_id[5:]
@@ -521,7 +559,7 @@ def get_pci_description(bus_id):
             raise Exception("Error: the Bus ID '%s' cannot be found in the PCI database" %
                             short_bus_id)
         else:
-            #Only the short ID is found in the record, so use this.
+            # Only the short ID is found in the record, so use this.
             bus_id = short_bus_id
 
     dev_rec = devices.devs[bus_id]
@@ -531,10 +569,11 @@ def get_pci_description(bus_id):
     description = IDS.findDevice(dev_rec['vendor'], dev_rec['device'])
     return "%s %s" % (vendor, description)
 
+
 def get_pci_subsystem(bus_id):
     """Return the PCI subsystem information for a specified bus location:"""
     log.debug("Getting subsystem for PCI device at bus id: %s" % bus_id)
-    
+
     call = ['/sbin/lspci', '-nn', '-v', '-s', bus_id]
     try:
         res = make_local_call(call)
@@ -543,12 +582,14 @@ def get_pci_subsystem(bus_id):
         log.debug("Exception: %s" % str(e))
     return ""
 
+
 @log_exceptions
 def create_output_package(session, args):
     """Create an output package for submission to Citrix"""
 
     dt = datetime.datetime.now()
-    tarfile_loc = "/root/ack-submission-%s.tar.gz" % dt.strftime('%H-%M-%d-%m-%Y')
+    tarfile_loc = "/root/ack-submission-%s.tar.gz" % dt.strftime(
+        '%H-%M-%d-%m-%Y')
 
     bugtool_loc = save_bugtool()
 
@@ -558,7 +599,8 @@ def create_output_package(session, args):
         if os.path.exists(file_loc):
             tar.add(file_loc)
         else:
-            log.debug("Cannot add %s to output package, does not exist" % file_loc)
+            log.debug(
+                "Cannot add %s to output package, does not exist" % file_loc)
 
     tar.add(bugtool_loc)
     tar.add("%s/test_run.conf" % INSTALL_DIR)
@@ -571,6 +613,7 @@ def create_output_package(session, args):
     tar.close()
     return json_dumps(tarfile_loc)
 
+
 def _pre_tampa_biosdevname():
     """Pre Tampa, we have to use the old biosdevname library"""
     import xcp.biosdevname
@@ -580,10 +623,10 @@ def _pre_tampa_biosdevname():
 
     type_key = 'Kernel name'
     pattern = re.compile(r'\d*:?[a-f0-9]+:[a-f0-9]+\.[a-f0-9]')
-    
-    return [device for device in biosdevobj.devices 
-                   if (device[type_key].startswith('eth') and pattern.match(device['Bus Info']))]
-    
+
+    return [device for device in biosdevobj.devices
+            if (device[type_key].startswith('eth') and pattern.match(device['Bus Info']))]
+
 
 def compat_biosdevname():
     """Return biosdevname, irrespective of system."""
@@ -593,7 +636,7 @@ def compat_biosdevname():
         return _pre_tampa_biosdevname()
 
     devs = xcp.net.biosdevname.all_devices_all_names()
-    
+
     devices = []
     pattern = re.compile(r'\d*:?[a-f0-9]+:[a-f0-9]+\.[a-f0-9]')
 
@@ -604,6 +647,7 @@ def compat_biosdevname():
 
     return devices
 
+
 @log_exceptions
 def get_network_devices(session, args):
     """Return a list of network devices and their corresponding properties"""
@@ -611,7 +655,7 @@ def get_network_devices(session, args):
 
     devices = []
     devs = compat_biosdevname()
-    
+
     # Filter for only network devices.
     for device in devs:
         log.debug("Device: %s" % device)
@@ -624,6 +668,7 @@ def get_network_devices(session, args):
 
     return json_dumps(devices)
 
+
 def _get_local_storage_disk(session):
     disk_path = get_from_xensource_inventory('PRIMARY_DISK')
     log.debug("Local Storage Disk Path: %s" % disk_path)
@@ -632,6 +677,8 @@ def _get_local_storage_disk(session):
     return os.path.basename(disk_path)
 
 __scsi_id_regex = re.compile("([\-\d\w\/]+)\-part\d+")
+
+
 def _get_local_storage_disks(session):
     """ Find all local disk """
 
@@ -661,9 +708,12 @@ def _get_local_storage_disks(session):
     return disks
 
 __bus_id_regex = re.compile("[0-9a-fA-F]{2}\:[0-9a-fA-F]{2}\.[0-9a-fA-F]")
+
+
 def _is_bus_id(bus_id):
     """ Check given bus_id is format of bus id """
     return __bus_id_regex.match(bus_id[-7:])
+
 
 def _get_bus_paths(disks):
     """ Find bus path of given disk. """
@@ -673,7 +723,8 @@ def _get_bus_paths(disks):
     for filename in os.listdir(device_path):
         fullpath = device_path + os.sep + filename
         if os.path.islink(fullpath) and os.path.basename(os.readlink(fullpath)) in disks.keys():
-            bus_paths[os.readlink(fullpath)] = disks[os.path.basename(os.readlink(fullpath))]
+            bus_paths[os.readlink(fullpath)] = disks[
+                os.path.basename(os.readlink(fullpath))]
 
     # paths in the list may not be the bus path but sym link to device.
     # If bus path does not include bus id, follow link to get bus path
@@ -687,16 +738,17 @@ def _get_bus_paths(disks):
                 linked_path = os.readlink(newpath)
                 if len(linked_path) < 5 or not _is_bus_id(linked_path.split(os.sep)[4]):
                     log.debug("%s or %s is not proper bus path. Failed to obtain bus path for %s" %
-                        (bus_path, linked_path, disk))
+                              (bus_path, linked_path, disk))
                 else:
                     modified_bus_path[linked_path] = sr
             else:
-                log.debug("Cannot find physical device or bus path of %s. Perhaps it is a logical volume." % disk)
+                log.debug(
+                    "Cannot find physical device or bus path of %s. Perhaps it is a logical volume." % disk)
         else:
             modified_bus_path[bus_path] = sr
 
     return modified_bus_path
-            
+
 
 def find_dir(dirpath, dirname, max_depth=2):
     """Find a file in a given directory, recursing a limited number of times"""
@@ -716,12 +768,12 @@ def find_dir(dirpath, dirname, max_depth=2):
 
     for depth in range(max_depth):
         log.debug("Directory Depth: %d" % depth)
-        
+
         # Take a copy of the list, so as to
         # force exiting the iteration to count depth.
         for path in list(paths):
             log.debug("Path: %s" % path)
-            
+
             # Ensure that the path actually exists
             if os.path.exists(path):
                 val, res = _find(path, dirname)
@@ -739,74 +791,77 @@ def find_dir(dirpath, dirname, max_depth=2):
                     # Append sub directories to the paths list
                     # for searching the next level down.
                     for item in res:
-                        paths.append("/".join([path,item]))
+                        paths.append("/".join([path, item]))
 
-    return results   
+    return results
 
 
 @log_exceptions
 def get_local_storage_devices(session, args):
     """Return a list of local storage devices and their corresponding properties"""
 
-    # Ensure that any exceptions raised as a result of find a non-expected device 
+    # Ensure that any exceptions raised as a result of find a non-expected device
     # passes back a failure message without halting execution.
 
     try:
-        
+
         disks = _get_local_storage_disks(session)
         log.debug("Local disks found: %s" % disks)
         bus_paths = _get_bus_paths(disks)
         log.debug("Buses found: %s" % bus_paths)
 
         if len(bus_paths) == 0:
-            return json_dumps([{'Exception':'Cannot find Storage interface.'}])
+            return json_dumps([{'Exception': 'Cannot find Storage interface.'}])
 
         # Enumerate PCI Devices
         devices = PCIDevices()
 
         storage_devices = []
         for bus_path, sr in bus_paths.iteritems():
-            
+
             bus_id = bus_path.split(os.sep)[4]
-    
+
             if bus_id.startswith('0000:'):
-                #We only care about the shortened id
+                # We only care about the shortened id
                 bus_id = bus_id[5:]
-    
+
             # Copy dictionary record for device at specified bus location
             device = dict(devices.devs[bus_id])
 
             device['PCI_id'] = get_pci_id(bus_id)
             device['PCI_description'] = get_pci_description(bus_id)
             device['PCI_subsystem'] = get_pci_subsystem(bus_id)
-    
+
             device['sr'] = sr
             driver_root_dir = "/sys/%s" % '/'.join(bus_path.split('/')[2:5])
-    
-            log.debug("Searching for driver sym link in '%s'" % driver_root_dir)
-                   
+
+            log.debug("Searching for driver sym link in '%s'" %
+                      driver_root_dir)
+
             driver_links = find_dir(driver_root_dir, 'driver')
-    
+
             if driver_links:
-                log.debug("Found the following driver sym-links: %s" % driver_links)
-    
+                log.debug("Found the following driver sym-links: %s" %
+                          driver_links)
+
                 # Take the first link - there should only be one, but this needs
                 # investigation on more bits of hardware, so let's not fail if there
                 # does exist more than one link.
                 driver_sym = driver_links[0]
                 log.debug("Reading driver from symlink: %s" % driver_sym)
-            
+
                 # Just check the path is still there.
                 if os.path.exists(driver_sym):
-                    device['driver'] = os.path.basename(os.readlink(driver_sym))
+                    device['driver'] = os.path.basename(
+                        os.readlink(driver_sym))
             if not device in storage_devices:
                 storage_devices.append(device)
-    
+
         return json_dumps(storage_devices)
 
     except Exception, e:
         log.debug("Could not get local storage info. Exception: %s" % str(e))
-        return json_dumps([{'Exception':'StorageInfoNotAvailable','Exception_Info':str(e)}])
+        return json_dumps([{'Exception': 'StorageInfoNotAvailable', 'Exception_Info': str(e)}])
 
 
 @log_exceptions
@@ -815,6 +870,7 @@ def get_vm_ip(session, args):
     vm_ref = validate_exists(args, 'vm_ref')
     device = validate_exists(args, 'device')
     return wait_for_ip(session, vm_ref, device)
+
 
 @log_exceptions
 def set_hw_offload(session, args):
@@ -828,6 +884,7 @@ def set_hw_offload(session, args):
     log.debug("Ethtool Command: %s" % call)
     return json_dumps(make_local_call(call)["stdout"])
 
+
 @log_exceptions
 def get_hw_offloads_from_core(session, args):
     """Return a dictionary object specifying offload protocols by
@@ -837,7 +894,8 @@ def get_hw_offloads_from_core(session, args):
         eth_dev = eth_dev.replace('xenbr', 'eth')
 
     rec = {}
-    flag = int(make_local_call(['cat', '/sys/class/net/%s/features' % eth_dev])['stdout'], 16)
+    flag = int(make_local_call(
+        ['cat', '/sys/class/net/%s/features' % eth_dev])['stdout'], 16)
 
     for offload, offset in OFFLOAD_FLAGS_OFFSET.iteritems():
         if offset & flag:
@@ -846,7 +904,8 @@ def get_hw_offloads_from_core(session, args):
             rec[offload] = 'off'
 
     return json_dumps(rec)
-        
+
+
 @log_exceptions
 def get_hw_offloads(session, args):
     """Return a dictionary object specifying offload protocols,
@@ -854,7 +913,7 @@ def get_hw_offloads(session, args):
     eth_dev = validate_exists(args, 'eth_dev')
     call = [ETHTOOL, '-k', eth_dev]
     offloads = make_local_call(call)["stdout"].split('\n')
-    #Remove the item at the top of the list
+    # Remove the item at the top of the list
     # "Offload parameters for ethX:"
     offloads.pop(0)
     rec = {}
@@ -867,6 +926,7 @@ def get_hw_offloads(session, args):
             rec[OFFLOAD_CODES[arr[0]]] = arr[1]
     return json_dumps(rec)
 
+
 @log_exceptions
 def get_network_backend(session, args):
     """Return the networking backend used by the pool"""
@@ -874,6 +934,7 @@ def get_network_backend(session, args):
     backend = fh.read()
     fh.close()
     return json_dumps(backend.strip())
+
 
 @log_exceptions
 def set_network_backend_pool(session, args):
@@ -884,20 +945,22 @@ def set_network_backend_pool(session, args):
     result = ""
     for host_ref in session.xenapi.host.get_all():
         out = session.xenapi.host.call_plugin(host_ref,
-                                        'autocertkit',
-                                        'set_network_backend',
-                                        args)
+                                              'autocertkit',
+                                              'set_network_backend',
+                                              args)
         result += "%s: %s " % (host_ref, out)
 
     return json_dumps(result)
 
+
 @log_exceptions
 def set_network_backend(session, args):
     """Set the backend used by the pool"""
-    #Note, this requires a host reboot to become effective
+    # Note, this requires a host reboot to become effective
     backend = validate_exists(args, 'backend')
     call = ['/opt/xensource/bin/xe-switch-network-backend', backend]
     return json_dumps(make_local_call(call)["stdout"])
+
 
 @log_exceptions
 def iperf_test(session, args):
@@ -910,8 +973,8 @@ def iperf_test(session, args):
     host_ref = session.xenapi.VM.get_resident_on(vm_ref)
     if session.xenapi.host.get_uuid(host_ref) != this_host_uuid:
         return session.xenapi.host.call_plugin(host_ref, 'autocertkit',
-                                                'iperf_test',
-                                                args)
+                                               'iperf_test',
+                                               args)
 
     window_size = validate_exists(args, 'window_size', False)
     format = validate_exists(args, 'format', False)
@@ -930,12 +993,13 @@ def iperf_test(session, args):
     copy(buffer_length, '-l')
     copy(thread_count, '-P')
     copy(dst_host, '-c')
-    
-    #Print MTU size
+
+    # Print MTU size
     call.append('-m')
 
     return json_dumps(make_local_call(call)["stdout"])
-    
+
+
 def parse_proc_net_dev(data):
     """Taking the contents of /proc/net/dev parse to provide a record"""
     lines = data.split('\n')
@@ -960,12 +1024,12 @@ def parse_proc_net_dev(data):
 @log_exceptions
 def add_route(session, args):
     """Add a network table route to a particular VM"""
-    vm_ref = validate_exists(args, 'vm_ref') 
+    vm_ref = validate_exists(args, 'vm_ref')
     device = validate_exists(args, 'device')
     dest_ip = validate_exists(args, 'dest_ip')
     gw = validate_exists(args, 'gw', required=False)
     mask = validate_exists(args, 'mask', required=False)
-   
+
     log.debug("add_route %s %s %s" % (vm_ref, device, dest_ip))
 
     if session.xenapi.VM.get_is_control_domain(vm_ref):
@@ -977,20 +1041,20 @@ def add_route(session, args):
         host_ref = session.xenapi.VM.get_resident_on(vm_ref)
         if session.xenapi.host.get_uuid(host_ref) != this_host_uuid:
             return session.xenapi.host.call_plugin(host_ref, 'autocertkit',
-                                                    'add_route',
-                                                    args)
+                                                   'add_route',
+                                                   args)
 
         bridge = _get_local_device_bridge(session, device)
         # Handle the case that we are dealing with Dom0
         # 1. Setup the correct routing entry in Dom0's routing table
-  
-        # Handle the default route case 
+
+        # Handle the default route case
         if dest_ip == '0.0.0.0' and mask == '0.0.0.0' and gw:
-            
+
             log.debug("Removing default gateway, before adding it back in")
             call = [IP, "route", "del", "default"]
             make_local_call(call)
-             
+
             call = [IP,
                     "route",
                     "add",
@@ -1001,20 +1065,20 @@ def add_route(session, args):
                     bridge]
 
         else:
-            call = [IP, 
-                    "route", 
-                    "add", 
+            call = [IP,
+                    "route",
+                    "add",
                     "%s/32" % dest_ip,
-                    "dev", 
+                    "dev",
                     bridge]
 
     else:
         # Handle the case we are adding a route to a VM
         vm_m_ip = wait_for_ip(session, vm_ref, 'eth0')
-        call = [SSH, 
-                vm_m_ip, IP, 
-                "route", 
-                "add", 
+        call = [SSH,
+                vm_m_ip, IP,
+                "route",
+                "add",
                 "%s/32" % dest_ip,
                 "dev",
                 device]
@@ -1036,6 +1100,7 @@ def remove_route(session, args):
 
     return json_dumps("OK")
 
+
 @log_exceptions
 def reset_arp(session, args):
     """Ensure that the switch knows which interfaces to 
@@ -1045,7 +1110,7 @@ def reset_arp(session, args):
     to send traffic too."""
 
     vm_ref = validate_exists(args, 'vm_ref')
-    
+
     log.debug("Reset ARP for VM %s" % vm_ref)
 
     arp_ipv4_ignore_config = "net.ipv4.conf.all.arp_ignore=1"
@@ -1061,11 +1126,11 @@ def reset_arp(session, args):
         pifs = session.xenapi.host.get_PIFs(host_ref)
         for pif in pifs:
             device = session.xenapi.PIF.get_device(pif)
-        
+
             # Execute a gratuitus ARP for the device in question
             # translate device name into bridge
             bridge = _get_local_device_bridge(session, device)
-        
+
             log.debug("About to send gARP out on %s" % bridge)
 
             bridge_dev = _get_local_device(bridge)
@@ -1075,11 +1140,11 @@ def reset_arp(session, args):
             else:
                 call = [ARPING, "-c", '10', '-A', '-I', bridge, bridge_dev.ip]
                 make_local_call(call)
-        
+
     else:
         # Handle the Droid VM case
         vm_m_ip = wait_for_ip(session, vm_ref, 'eth0')
-        
+
         # Global ARP Ignore
         cmd = "%s net.ipv4.conf.all.arp_ignore=1" % SYSCTL
         call = [SSH, vm_m_ip, cmd]
@@ -1089,13 +1154,15 @@ def reset_arp(session, args):
         for vif in vifs:
             device_id = session.xenapi.VIF.get_device(vif)
             device = "eth%s" % device_id
-       
+
             # Execute a gratuitus ARP for the device in question
             device_ip = wait_for_ip(session, vm_ref, device)
-            call = [SSH, vm_m_ip, ARPING, "-c", '10', '-A', '-I', device, device_ip]
+            call = [SSH, vm_m_ip, ARPING, "-c",
+                    '10', '-A', '-I', device, device_ip]
             make_local_call(call)
 
     return json_dumps("OK")
+
 
 def get_iface_stats(session, args):
     """Use ethtool to return a list of statistics for a given interface"""
@@ -1104,7 +1171,7 @@ def get_iface_stats(session, args):
     log.debug("Iface passed in %s" % iface_name)
     data = None
     arch = None
-    
+
     if session.xenapi.VM.get_is_control_domain(vm_ref):
         host_ref = session.xenapi.VM.get_resident_on(vm_ref)
         this_host_uuid = get_from_xensource_inventory('INSTALLATION_UUID')
@@ -1119,20 +1186,20 @@ def get_iface_stats(session, args):
 
         else:
             # Proxy the command to the correct host
-            return session.xenapi.host.call_plugin(host_ref, 
-                                                  'autocertkit', 
-                                                  'get_iface_stats', 
-                                                  args)
+            return session.xenapi.host.call_plugin(host_ref,
+                                                   'autocertkit',
+                                                   'get_iface_stats',
+                                                   args)
     else:
         # Dealing with a non-control domain. SSH and obtain result
         vm_m_ip = wait_for_ip(session, vm_ref, 'eth0')
         log.debug("IP address for VM '%s' is '%s'" % (vm_ref,
                                                       vm_m_ip))
-    
+
         # Note, we rely on an SSH key being setup for this
         # droid VM.
 
-        call = [SSH, vm_m_ip, CAT, '/proc/net/dev']     
+        call = [SSH, vm_m_ip, CAT, '/proc/net/dev']
         log.debug("About to make SSH call: %s" % call)
 
         data = make_local_call(call)["stdout"]
@@ -1151,7 +1218,7 @@ def get_iface_stats(session, args):
 
     if iface_name not in rec.keys():
         log.error("Error: could not find iface '%s' in stats (%s)" %
-                    (iface_name, rec.keys()))
+                  (iface_name, rec.keys()))
 
     device_stats = rec[iface_name]
 
@@ -1163,6 +1230,7 @@ def get_iface_stats(session, args):
 
     return json_dumps(device_stats)
 
+
 @log_exceptions
 def get_host_routes(session, args):
     """Return a XML dictionary list of host routes"""
@@ -1171,6 +1239,7 @@ def get_host_routes(session, args):
     return json_dumps(route_recs)
 
 ############### Host Crash #######################
+
 
 @log_exceptions
 def force_crash_host(session, args):
@@ -1191,6 +1260,7 @@ def force_crash_host(session, args):
     # Give some time to crash.
     time.sleep(5)
 
+
 @log_exceptions
 def _retrieve_crashdumps_from_xapi(session, host):
     """Search for crashdumps using xapi."""
@@ -1200,15 +1270,17 @@ def _retrieve_crashdumps_from_xapi(session, host):
         if not host == session.xenapi.host_crashdump.get_host(cd):
             continue
         ret.append({'host': host,
-            'timestamp': str(session.xenapi.host_crashdump.get_timestamp(cd)),
-            'size': str(session.xenapi.host_crashdump.get_size(cd)),
-            'uuid': session.xenapi.host_crashdump.get_uuid(cd),
-            'other-config': str(session.xenapi.host_crashdump.get_other_config(cd))
-            })
+                    'timestamp': str(session.xenapi.host_crashdump.get_timestamp(cd)),
+                    'size': str(session.xenapi.host_crashdump.get_size(cd)),
+                    'uuid': session.xenapi.host_crashdump.get_uuid(cd),
+                    'other-config': str(session.xenapi.host_crashdump.get_other_config(cd))
+                    })
 
     return ret
 
 CD_PATTERN = re.compile(r'\d{8}\-\d{6}\-.*')
+
+
 @log_exceptions
 def _retrieve_crashdumps(session, host):
     """Search for crashdumps from /var/crash."""
@@ -1220,18 +1292,19 @@ def _retrieve_crashdumps(session, host):
     for apath in os.listdir(CD_LOC):
         if not CD_PATTERN.match(apath):
             continue
-        size = 4096 # directory itself is size of 4096
+        size = 4096  # directory itself is size of 4096
         cdpath = CD_LOC + os.sep + apath
         for logfile in os.listdir(cdpath):
             if not os.path.isfile(cdpath + os.sep + logfile):
                 continue
             size += os.path.getsize(cdpath + os.sep + logfile)
         ret.append({'host': host,
-            'timestamp': str(apath),
-            'size': str(size)
-            })
+                    'timestamp': str(apath),
+                    'size': str(size)
+                    })
 
     return ret
+
 
 def retrieve_crashdumps(session, args):
     """Search all crashdumps and return."""
@@ -1249,7 +1322,8 @@ def retrieve_crashdumps(session, args):
 def install_rpm(session, rpm_name, vm_ref, username, password):
     """Install a predefined RPM"""
     ip_address = wait_for_ip(session, vm_ref, 'eth0')
-    call = ['/usr/bin/scp', "-o", "StrictHostKeyChecking=no", "/opt/xensource/packages/files/auto-cert-kit/%s" % rpm_name, 'root@%s:' % ip_address]
+    call = ['/usr/bin/scp', "-o", "StrictHostKeyChecking=no",
+            "/opt/xensource/packages/files/auto-cert-kit/%s" % rpm_name, 'root@%s:' % ip_address]
     log.debug(call)
     make_local_call(call)
     cmd_str = "rpm -i /root/%s --nosignature" % rpm_name
@@ -1262,22 +1336,25 @@ def install_rpm(session, rpm_name, vm_ref, username, password):
 def copy_lmbench_config(session, vm_ref, username, password):
     """Copy the LMbench config file to a VM"""
     if not os.path.exists(LMBENCH_CONF_LOC):
-        raise Exception("LMbench config file is not present in %s" % LMBENCH_CONF_LOC)
+        raise Exception("LMbench config file is not present in %s" %
+                        LMBENCH_CONF_LOC)
     ip_address = wait_for_ip(session, vm_ref, 'eth0')
 
     # Determine where lmbench will be looking for the config
     # file, so that we can copy it to the correct place.
     cmd_str = "/usr/lib/lmbench/scripts/config"
     config_file_name = ssh_command(ip_address, username, password, cmd_str)
-        
-    log.debug("Deterined that VM %s needs lmbench config file named: %s" % (vm_ref, config_file_name))
-    
+
+    log.debug("Deterined that VM %s needs lmbench config file named: %s" %
+              (vm_ref, config_file_name))
+
     call = ['/usr/bin/scp',
             "-o", "StrictHostKeyChecking=no",
             LMBENCH_CONF_LOC,
             'root@%s:/usr/lib/lmbench/bin/i686-pc-linux-gnu/%s' % (ip_address, config_file_name)]
     log.debug(call)
     return make_local_call(call)["stdout"]
+
 
 @log_exceptions
 def deploy_lmbench(session, args):
@@ -1299,14 +1376,16 @@ def deploy_lmbench(session, args):
                 copy_lmbench_config(session, vm_ref, username, password)
                 break
             except:
-                log.debug("Exception raised attempting to deploy LMbench. Attempt %d" % i)
-                time.sleep(5) #Sleep 5 seconds
-                i = i + 1 #Increment counter
+                log.debug(
+                    "Exception raised attempting to deploy LMbench. Attempt %d" % i)
+                time.sleep(5)  # Sleep 5 seconds
+                i = i + 1  # Increment counter
                 if i == limit:
                     raise Exception("Cannot deploy LMbench")
-                
+
     log.debug("LMbench installation completed")
     return json_dumps("OK")
+
 
 @log_exceptions
 def retrieve_lmbench_logs(session, args):
@@ -1323,7 +1402,8 @@ def retrieve_lmbench_logs(session, args):
     response = ssh_command(ip_address, username, password, cmd_str)
 
     if int(response) == 0:
-        raise Exception("Couldn't find any results files in directory '%s'" % results_dir)
+        raise Exception(
+            "Couldn't find any results files in directory '%s'" % results_dir)
 
     # Make sure the local lmbench results dir exists
     if not os.path.exists(LMBENCH_RESULTS_DIR):
@@ -1335,19 +1415,20 @@ def retrieve_lmbench_logs(session, args):
     os.mkdir(vm_lmbench_results_dir)
 
     # SCP the logs to the master host
-    call = ["/usr/bin/scp", "-o", "StrictHostKeyChecking=no", 
-            "root@%s:/usr/lib/lmbench/results/i686-pc-linux-gnu/*" % ip_address, 
+    call = ["/usr/bin/scp", "-o", "StrictHostKeyChecking=no",
+            "root@%s:/usr/lib/lmbench/results/i686-pc-linux-gnu/*" % ip_address,
             vm_lmbench_results_dir]
 
     log.debug(call)
     return json_dumps(make_local_call(call)["stdout"])
+
 
 def lmbench_test(session):
     """Run LMbench"""
     call = [LMBENCH]
     log.debug(call)
     return make_local_call(call)["stdout"]
-    
+
 
 ############### Iozone Setup #########################
 
@@ -1369,14 +1450,16 @@ def deploy_iozone(session, args):
                 install_rpm(session, IOZONE_RPM, vm_ref, username, password)
                 break
             except:
-                log.debug("Exception raised attempting to deploy Iozone. Attempt %d" % i)
-                time.sleep(5) #Sleep 5 seconds
-                i = i + 1 #Increment counter
+                log.debug(
+                    "Exception raised attempting to deploy Iozone. Attempt %d" % i)
+                time.sleep(5)  # Sleep 5 seconds
+                i = i + 1  # Increment counter
                 if i == limit:
                     raise Exception("Cannot deploy Iozone")
-                
+
     log.debug("Iozone installation completed")
     return json_dumps("OK")
+
 
 @log_exceptions
 def retrieve_iozone_logs(session, args):
@@ -1394,10 +1477,11 @@ def retrieve_iozone_logs(session, args):
         raise Exception("Cannot retrieve Iozone log from VM %s" % vm_ref)
 
     # SCP the logs to the master host
-    call = ["/usr/bin/scp", "-o", "StrictHostKeyChecking=no", "root@%s:/root/localhost.log" % ip_address, "/opt/xensource/packages/files/auto-cert-kit/iozone.log"]
+    call = ["/usr/bin/scp", "-o", "StrictHostKeyChecking=no", "root@%s:/root/localhost.log" %
+            ip_address, "/opt/xensource/packages/files/auto-cert-kit/iozone.log"]
     log.debug(call)
     return json_dumps(make_local_call(call)["stdout"])
-  
+
 
 ############### Bonnie++ Setup #########################
 
@@ -1418,17 +1502,20 @@ def deploy_bonnie(session, args):
                 install_ssh_key(session, vm_ref, username, password)
                 install_rpm(session, BONNIE_RPM, vm_ref, username, password)
                 vm_ip = wait_for_ip(session, vm_ref, 'eth0')
-                ssh_command(vm_ip, username, password, 'mkdir -m a=rwx /root/bonnie; useradd citrix; chown citrix /root/bonnie')
+                ssh_command(vm_ip, username, password,
+                            'mkdir -m a=rwx /root/bonnie; useradd citrix; chown citrix /root/bonnie')
                 break
             except:
-                log.debug("Exception raised attempting to deploy Bonnie++. Attempt %d" % i)
-                time.sleep(5) #Sleep 5 seconds
-                i = i + 1 #Increment counter
+                log.debug(
+                    "Exception raised attempting to deploy Bonnie++. Attempt %d" % i)
+                time.sleep(5)  # Sleep 5 seconds
+                i = i + 1  # Increment counter
                 if i == limit:
                     raise Exception("Cannot deploy Bonnie++")
-                
+
     log.debug("Bonnie++ installation completed")
     return json_dumps("OK")
+
 
 @log_exceptions
 def retrieve_bonnie_logs(session, args):
@@ -1446,10 +1533,11 @@ def retrieve_bonnie_logs(session, args):
         raise Exception("Cannot retrieve Bonnie++ log from VM %s" % vm_ref)
 
     # SCP the logs to the master host
-    call = ["/usr/bin/scp", "-o", "StrictHostKeyChecking=no", "root@%s:/root/localhost.log" % ip_address, "/opt/xensource/packages/files/auto-cert-kit/bonnie.log"]
+    call = ["/usr/bin/scp", "-o", "StrictHostKeyChecking=no", "root@%s:/root/localhost.log" %
+            ip_address, "/opt/xensource/packages/files/auto-cert-kit/bonnie.log"]
     log.debug(call)
     return json_dumps(make_local_call(call)["stdout"])
-  
+
 
 ############### Main #########################
 
@@ -1462,7 +1550,8 @@ def handle_ipv4_static_conf(session, vm_uuid, iface, args):
     vm_ref = session.xenapi.VM.get_by_uuid(vm_uuid)
 
     def add_config(key, value):
-        session.xenapi.VM.add_to_xenstore_data(vm_ref, "vm-data/control/%s/%s" % (iface, key), value)
+        session.xenapi.VM.add_to_xenstore_data(
+            vm_ref, "vm-data/control/%s/%s" % (iface, key), value)
 
     add_config('ip', ip)
     add_config('netmask', netmask)
@@ -1470,9 +1559,11 @@ def handle_ipv4_static_conf(session, vm_uuid, iface, args):
 
     return 'OK'
 
+
 def handle_ipv6_static_conf(session, vm_uuid, iface, args):
     raise Exception("IPv6 support has not been implemented for this plugin")
     return None
+
 
 @log_exceptions
 def droid_set_static_conf(session, args):
@@ -1481,7 +1572,7 @@ def droid_set_static_conf(session, args):
     iface = validate_exists(args, 'iface')
     protocol = validate_exists(args, 'protocol').lower()
 
-    if protocol not in ["ipv4","ipv6"]:
+    if protocol not in ["ipv4", "ipv6"]:
         raise Exception("Currently, static addressing is only supported for ipv4 or ivp6. (%s)" %
                         protocol)
 
@@ -1492,22 +1583,25 @@ def droid_set_static_conf(session, args):
     else:
         raise Exception("Unexpected error ('%s')" % protocol)
 
+
 @log_exceptions
 def droid_template_import(session, args):
     """Import a xva using fully specified location"""
-    #Need to encode/decode URI as it has unsafe characters for transmission.
+    # Need to encode/decode URI as it has unsafe characters for transmission.
     filename = DROID_VM_LOC
     sr_uuid = validate_exists(args, 'sr_uuid')
     call = [XE, 'vm-import', 'filename=%s' % filename, 'sr-uuid=%s' % sr_uuid]
     return json_dumps(make_local_call(call)["stdout"])
 
+
 def process_running(process_name):
-    process_list = make_local_call([PS,'aux'])["stdout"].split('\n')
+    process_list = make_local_call([PS, 'aux'])["stdout"].split('\n')
     for process in process_list:
         if process_name in process:
             log.debug("Process Found: %s" % process)
             return True
     return False
+
 
 def kill_processes(process_name):
     process_list = make_local_call([PGREP, process_name])["stdout"].split('\n')
@@ -1520,13 +1614,14 @@ def kill_processes(process_name):
         if regex.match(process):
             make_local_call([KILL, '-9', process])
 
+
 def mark_local_pif_for_cleanup(session, device):
     # Undo any transformations between bridges/devices that may
     # have taken place already
     if 'xenbr' in device:
         device = device.replace('xenbr', 'eth')
 
-    this_host_uuid = get_from_xensource_inventory('INSTALLATION_UUID') 
+    this_host_uuid = get_from_xensource_inventory('INSTALLATION_UUID')
 
     host_ref = session.xenapi.host.get_by_uuid(this_host_uuid)
     pifs = session.xenapi.host.get_PIFs(host_ref)
@@ -1542,12 +1637,13 @@ def mark_local_pif_for_cleanup(session, device):
     raise Exception("Error: unable to find PIF for '%s' in '%s'" %
                     (device, pifs))
 
+
 def run_dhclient(device):
     """Run dhclient on a specified interface. If a process already
     exists, then also take care of killing that process and starting
     dhclient up on the specified device again."""
 
-    cmd = [DHCLIENT, "-q", "-lf", 
+    cmd = [DHCLIENT, "-q", "-lf",
            "/var/lib/dhclient/dhclient-%s.leases" % device,
            "-pf", "/var/run/dhclient-%s.pid" % device, device]
 
@@ -1562,21 +1658,21 @@ def run_dhclient(device):
             arr = process.split()
             pid = arr[1]
             make_local_call([KILL, '-9', pid])
-            time.sleep(3) # Give some time to ensure process kill
+            time.sleep(3)  # Give some time to ensure process kill
 
     res = make_local_call(cmd)["stdout"]
 
     return res
 
-   
+
 def _configure_local_device_ip(session, device, ip_addr, ip_netmask, mode):
     log.debug("Configure local device IP: (%s) (%s) (%s) (%s)" % (device,
-                                                             ip_addr,
-                                                             ip_netmask,
-                                                             mode))
+                                                                  ip_addr,
+                                                                  ip_netmask,
+                                                                  mode))
     # Mark the PIF as needing cleaning up
-    mark_local_pif_for_cleanup(session, device) 
-    
+    mark_local_pif_for_cleanup(session, device)
+
     if mode.lower() == "dhcp":
         # DHCP Case
         run_dhclient(device)
@@ -1590,11 +1686,12 @@ def _configure_local_device_ip(session, device, ip_addr, ip_netmask, mode):
 
     if not dev.ip:
         log.error("Settings Device: %s, IP: %s, Mask: %s" % (device,
-                                                            dev.ip,
-                                                            dev.mask))
+                                                             dev.ip,
+                                                             dev.mask))
         raise Exception("Error: failed to set IP for '%s'" % device)
 
     return dev
+
 
 def _get_local_device_bridge(session, device):
     """
@@ -1606,7 +1703,8 @@ def _get_local_device_bridge(session, device):
     for pif in session.xenapi.host.get_PIFs(host):
         if device == session.xenapi.PIF.get_device(pif):
             network = session.xenapi.PIF.get_network(pif)
-            log.debug("Found matching bridge on PIF %s of network %s." % (pif, network))
+            log.debug("Found matching bridge on PIF %s of network %s." %
+                      (pif, network))
             return session.xenapi.network.get_bridge(network)
 
     for network in session.xenapi.network.get_all():
@@ -1625,6 +1723,7 @@ def _get_local_device_bridge(session, device):
 
     return device
 
+
 @log_exceptions
 def get_local_device_info(session, args):
     device = validate_exists(args, 'device')
@@ -1633,6 +1732,7 @@ def get_local_device_info(session, args):
     log.debug("get_local_device_info for %s" % devname)
     dev = _get_local_device(devname)
     return json_dumps(dev.to_rec())
+
 
 @log_exceptions
 def get_local_device_ip(session, args):
@@ -1645,6 +1745,7 @@ def get_local_device_ip(session, args):
     if not dev.ip:
         raise Exception("Error: could not obtain an IP for %s" % device)
     return json_dumps(dev.ip)
+
 
 def _get_local_device(device_name):
     """Use ifconfig to get the IP address of a specified interface
@@ -1696,21 +1797,22 @@ def configure_local_device_ip(session, device_name, ip_addr, ip_netmask, mode):
     device name in order to run a service bound to that interface"""
 
     log.debug("configure_local_device_ip (%s) (%s) (%s) (%s)" % (device_name,
-                                                      ip_addr,
-                                                      ip_netmask,
-                                                      mode))
+                                                                 ip_addr,
+                                                                 ip_netmask,
+                                                                 mode))
 
     device = _get_local_device_bridge(session, device_name.lower())
     dev = _get_local_device(device)
 
     if not dev.ip or not dev.mask:
-        dev = _configure_local_device_ip(session, 
-                                        device, 
-                                        ip_addr, 
-                                        ip_netmask,
-                                        mode)
+        dev = _configure_local_device_ip(session,
+                                         device,
+                                         ip_addr,
+                                         ip_netmask,
+                                         mode)
 
     return dev
+
 
 @log_exceptions
 def flush_local_device(session, args):
@@ -1723,8 +1825,9 @@ def flush_local_device(session, args):
 
     return json_dumps("OK")
 
+
 @log_exceptions
-def configure_local_device(session, args):  
+def configure_local_device(session, args):
     """Configure a local ethernet interface"""
     device = validate_exists(args, 'device')
     mode = validate_exists(args, 'mode')
@@ -1742,7 +1845,8 @@ def configure_local_device(session, args):
 
     dev = configure_local_device_ip(session, device, ip_addr, ip_netmask, mode)
     return json_dumps("OK")
-    
+
+
 @log_exceptions
 def start_iperf_server(session, args):
     """Start up iPerf in sever mode. This command will block - due to how iperf returns
@@ -1755,18 +1859,19 @@ def start_iperf_server(session, args):
 
     ip_addr = None
     ip_netmask = None
-    
+
     if mode == "static":
         ip_addr = validate_exists(args, 'ip_addr')
         ip_netmask = validate_exists(args, 'ip_netmask')
     else:
         if mode.lower() != "dhcp":
             raise Exception("Error: invalid 'mode' '%s'" % mode)
-    
-    dev = configure_local_device_ip(session, device_name, ip_addr, ip_netmask, mode)
+
+    dev = configure_local_device_ip(
+        session, device_name, ip_addr, ip_netmask, mode)
 
     kill_processes('iperf')
-     
+
     # Check for iperfs existence
     if not process_running(IPERF):
         log.debug("Iperf is not running - start process")
@@ -1774,18 +1879,18 @@ def start_iperf_server(session, args):
         call = ['service', 'iptables', 'stop']
         make_local_call(call)
 
-        #Start iperf daemon - need to ensure we don't block
+        # Start iperf daemon - need to ensure we don't block
         call = [IPERF, '-s', '-D', '-B', dev.ip]
         log.debug("About to start iperf server daemon (%s)" % call)
-        subprocess.Popen(call, stdout=subprocess.PIPE, 
-                         stderr=subprocess.PIPE, 
+        subprocess.Popen(call, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
                          close_fds=True, bufsize=4096)
 
         log.debug("Call executed")
 
         max_attempts = 10
         attempts = 0
-        #Ensure that the iperf server has actually been started
+        # Ensure that the iperf server has actually been started
         while not process_running(IPERF) or attempts > max_attempts:
             log.debug("%d: Iperf server not yet started...waiting" % attempts)
             time.sleep(1)
@@ -1801,6 +1906,7 @@ def start_iperf_server(session, args):
         raise Exception("ERR: did not kill all iperf processes")
 
 ############# Utility function #####################
+
 
 @log_exceptions
 def get_kernel_version(session, args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 paramiko
 coveralls
+autopep8

--- a/setup-supp-pack.py
+++ b/setup-supp-pack.py
@@ -11,10 +11,10 @@ parser.add_option('--out', dest="outdir")
 (options, args) = parser.parse_args()
 
 xs = Requires(originator='xcp', name='main', test='ge',
-               product=options.platform_name, version='1.0.99',
-               build='50762p')
+              product=options.platform_name, version='1.0.99',
+              build='50762p')
 
-setup(originator='xs', name='xs-auto-cert-kit', product=options.platform_name, 
-      version=options.platform_version, build=options.build, vendor='Citrix Systems, Inc.', 
+setup(originator='xs', name='xs-auto-cert-kit', product=options.platform_name,
+      version=options.platform_version, build=options.build, vendor='Citrix Systems, Inc.',
       description="XenServer Auto Cert Kit", packages=args, requires=[xs],
       outdir=options.outdir, output=['iso'])

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,4 @@ setup(name='AutoCertKit',
       author='Citrix System Inc.',
       url='http://github.com/xenserver/auto-cert-kit',
       packages=['autocertkit', 'XenAPI', 'acktools', 'acktools.net'],
-     )
-
-
+      )

--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -1,16 +1,15 @@
 #!/bin/sh
-if [ $# -eq 0 ]
-then
-echo "Automated extra/missing whitespace code correction using autopep8"
-files=`find ../ -not -path "../XenAPI/*" |
-    egrep -e '\.(py)$$' -e 'plugins/autocertkit' |
-    sort | uniq`
+pwd0="$(dirname "$0")"
+if [ $# -eq 0 ] ; then
+    echo "Automated extra/missing whitespace code correction using autopep8"
+    files=`find $pwd0/../ -not -path "$pwd0/../XenAPI/*" |
+        egrep -e '\.(py)$$' -e 'plugins/autocertkit' |
+        sort | uniq`
 else
-files="$1"
+    files="$1"
 fi 
 
-for file in $files
-do
+for file in $files ; do
     echo "Running autopep8 on $file for whitespace changes only..."
     autopep8 -i $file
 done

--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+if [ $# -eq 0 ]
+then
+echo "Automated extra/missing whitespace code correction using autopep8"
+files=`find ../ -not -path "../XenAPI/*" |
+    egrep -e '\.(py)$$' -e 'plugins/autocertkit' |
+    sort | uniq`
+else
+files="$1"
+fi 
+
+for file in $files
+do
+    echo "Running autopep8 on $file for whitespace changes only..."
+    autopep8 -i $file
+done

--- a/tools/checkpep8.sh
+++ b/tools/checkpep8.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+pwd0="$(dirname "$0")"
+$pwd0/autopep8.sh
+if [ "$(git diff)" ]] ; then
+    echo "checkpep8: Found violations, use tools/autopep8.sh to fix."
+    echo "checkpep8: Expected fix:-"
+    git diff
+    exit 1
+else
+    echo "checkpep8: No violations found. Success"
+fi


### PR DESCRIPTION
This merge request contains two changes:
1. Adding tools/autopep8.sh : 
Autopep8 tool can run in on all python files in a go in ACK project and
correct missing/extra white space as per pep8 guidelines. Autopep8
package has capability to do advance code violation fixing, though
it might lead to reduction in readability and might not be preferred
for ACK. Hence this tool is being used only for white space corrections.

2. Running tools/autopep8.sh, contains whitespace change only 
this has corrected all whitespace issues as per pep8 guideline into project and is done in single commit. this commit contains only whitespace changes and is not supposed to affect functionality.