### PR TITLE
CA-227289: ACK is now an update instead of supp-pack

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -2424,12 +2424,13 @@ def wait_for_hosts(session, timeout=300):
     raise Exception("Hosts(%s) failed to come back online" % hosts)
 
 
-def get_ack_version(session, host):
+def get_ack_version(session, host=None):
     """Return the version string corresponding to the cert kit on a particular host"""
-    sw = session.xenapi.host.get_software_version(host)
-    key = 'xs:xs-auto-cert-kit'
-    if key in sw.keys():
-        return sw[key]
+    try:
+        return call_ack_plugin(session, 'get_ack_version', {}, host=host)
+    except XenAPI.Failure, e:
+        log.debug("Failed to execute ack plugin call means ACK is not installed.")
+        return None
 
 
 def combine_recs(rec1, rec2):

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -1913,6 +1913,20 @@ def get_kernel_version(session, args):
     """Check kernel version using uname."""
     return json_dumps(make_local_call(['uname', '-r'])["stdout"])
 
+
+@log_exceptions
+def get_ack_version(session, args):
+    """Check ACK version using `rpm -qi`"""
+    call = ['rpm', '-qi', 'xenserver-auto-cert-kit']
+    out = make_local_call(call)
+    if out['returncode']:
+        return json_dumps(None)
+    ver = [i.split(":")[-1]
+           for i in out['stdout'].split("\n") if i.startswith('Version')]
+    if ver and len(ver) == 1:
+        return json_dumps(ver[0].strip())
+    raise Exception("Unable to parse ack version")
+
 #####################################################
 
 if __name__ == '__main__':
@@ -1950,6 +1964,7 @@ if __name__ == '__main__':
                            'get_local_device_info': get_local_device_info,
                            'inject_ssh_key': inject_ssh_key,
                            'get_kernel_version': get_kernel_version,
+                           'get_ack_version': get_ack_version,
                            'run_ack_logrotate': run_ack_logrotate,
                            'retrieve_crashdumps': retrieve_crashdumps,
                            'force_crash_host': force_crash_host


### PR DESCRIPTION
ACK does pre-check if ack is also installed on slave or not. Since ACK is now an update hence need to check `rpm -qi`