### PR TITLE
Refactor XenAPIMock* classes to allow unitttest scalabality. Allow mu…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - "pip install -r requirements.txt"
 
 script: 
-    - nosetests -c .noserc autocertkit/tests/ acktools/
+    - nosetests -c .noserc autocertkit/tests/ acktools/ -v
     - tools/checkpep8.sh
 
 after_success:

--- a/autocertkit/tests/utils_tests.py
+++ b/autocertkit/tests/utils_tests.py
@@ -254,13 +254,13 @@ class CheckGetMethodsTests(unittest.TestCase):
         self.assertEqual(utils.get_ack_version(
             s1, s1.hosts[1].opaque), "1.2.3")
 
-        s2 = xenapi_mock.Session("ACK is not installed on slave")
+        s1.hosts[1].setAckVersion(None)
         self.assertEqual(utils.get_ack_version(
-            s2, s2.hosts[0].opaque), "1.2.3")
-        self.assertEqual(utils.get_ack_version(s2, s2.hosts[1].opaque), None)
+            s1, s1.hosts[0].opaque), "1.2.3")
+        self.assertEqual(utils.get_ack_version(s1, s1.hosts[1].opaque), None)
 
-        s2.fail_plugin = True
-        self.assertEqual(utils.get_ack_version(s2), None)
+        s1.fail_plugin = True
+        self.assertEqual(utils.get_ack_version(s1), None)
 
 if __name__ == '__main__':
     unittest.main()

--- a/autocertkit/tests/utils_tests.py
+++ b/autocertkit/tests/utils_tests.py
@@ -246,5 +246,21 @@ class SimpleMethodsTests(unittest.TestCase):
         self.assertFalse(utils.is_64_bit("i686"))
 
 
+class CheckGetMethodsTests(unittest.TestCase):
+
+    def test_get_ack_version(self):
+        s1 = xenapi_mock.Session()
+        self.assertEqual(utils.get_ack_version(s1), "1.2.3")
+        self.assertEqual(utils.get_ack_version(
+            s1, s1.hosts[1].opaque), "1.2.3")
+
+        s2 = xenapi_mock.Session("ACK is not installed on slave")
+        self.assertEqual(utils.get_ack_version(
+            s2, s2.hosts[0].opaque), "1.2.3")
+        self.assertEqual(utils.get_ack_version(s2, s2.hosts[1].opaque), None)
+
+        s2.fail_plugin = True
+        self.assertEqual(utils.get_ack_version(s2), None)
+
 if __name__ == '__main__':
     unittest.main()

--- a/autocertkit/tests/xenapi_mock.py
+++ b/autocertkit/tests/xenapi_mock.py
@@ -11,7 +11,7 @@ import json
 from XenAPI import XenAPI
 
 
-class XenAPIObjectMock(object):
+class XenObjectMock(object):
     """Base class for XenAPI object models"""
 
     USED_SUFFIXES = []
@@ -41,41 +41,13 @@ class XenAPIObjectMock(object):
         return self.__uuid
 
 
-class Session(XenAPIObjectMock):
+class Session(XenObjectMock):
     """Session data structure for XenAPI Session mock"""
 
-    __INSTANCE = {}
-    __INITIALIZED = {}
-
-    def __new__(cls, desc="Generic"):
-        # There can be only 1 session during tests per desc.
-        if desc not in Session.__INSTANCE:
-            Session.__INSTANCE[desc] = super(Session, cls).__new__(cls)
-            Session.__INITIALIZED[desc] = False
-        return Session.__INSTANCE[desc]
-
-    def __init__(self, desc="Generic"):
-        if not self.__INITIALIZED[desc]:
-            super(Session, self).__init__()
-            self.fail_plugin = False
-
-            if desc == "EmptySession":
-                # Session is empty
-                self.__initEmptySession()
-            else:
-                # Standard session - 2 hosts, 1 network
-                self.__initGenericSession()
-
-            if desc == "ACK is not installed on slave":
-                self.hosts[1].setAckVersion(None)
-
-            self.__INITIALIZED[desc] = True
-
-    def __initEmptySession(self):
-        self.__Pool = None
-        self.__opaque = None
-        self.__xenapi = None
-        self.__networks = None
+    def __init__(self):
+        super(Session, self).__init__()
+        self.fail_plugin = False
+        self.__initGenericSession()
 
     def __initGenericSession(self, hosts=2, networks=1):
         self.__networks = [Network(i) for i in xrange(networks)]
@@ -103,7 +75,7 @@ class Session(XenAPIObjectMock):
         return self.__networks
 
 
-class Network(XenAPIObjectMock):
+class Network(XenObjectMock):
     """Network data structure for XenAPI Network mock"""
 
     def __init__(self, netid, bridge="xenbr"):
@@ -133,7 +105,7 @@ class Bond(Network):
         self.pifs = pifs
 
 
-class PIF(XenAPIObjectMock):
+class PIF(XenObjectMock):
     """PIF data structure for XenAPI PIC mock"""
 
     def __init__(self, host, network, devid):
@@ -173,7 +145,7 @@ class PIF(XenAPIObjectMock):
         return self.__network
 
 
-class Pool(XenAPIObjectMock):
+class Pool(XenObjectMock):
     """Pool data structure for XenAPI Pool mock"""
 
     def __init__(self, hosts, networks):
@@ -185,12 +157,12 @@ class Pool(XenAPIObjectMock):
         return self.__hosts
 
 
-class Host(XenAPIObjectMock):
+class Host(XenObjectMock):
     """Host data structure for XenAPI Host mock"""
 
     def __init__(self, networks):
         super(Host, self).__init__()
-        self.__metrics = HostMetrics(self)
+        self.__metrics = HostMetrics()
         self.__pifs = [PIF(self, networks[i], i * 2) for i in xrange(len(networks))] + \
             [PIF(self, networks[i], i * 2 + 1) for i in xrange(len(networks))]
         for pif in self.__pifs:
@@ -248,12 +220,11 @@ class Host(XenAPIObjectMock):
         del self.__supportedPlugins[name]
 
 
-class HostMetrics(XenAPIObjectMock):
+class HostMetrics(XenObjectMock):
     """Host metric data structure for XenAPI Hose Metrics mock"""
 
-    def __init__(self, host):
+    def __init__(self):
         super(HostMetrics, self).__init__()
-        self.__host = host
         self.__live = True
 
     @property
@@ -265,7 +236,7 @@ class HostMetrics(XenAPIObjectMock):
         self.__live = liveness
 
 
-class VM(XenAPIObjectMock):
+class VM(XenObjectMock):
     """VM data structure for XenAPI VM mock"""
 
     def __init__(self, host, isdom0=False):

--- a/autocertkit/tests/xenapi_mock.py
+++ b/autocertkit/tests/xenapi_mock.py
@@ -310,10 +310,10 @@ class XenapiMock(mock.Mock):
         return self.__xenapiVm
 
 
-class _XenapiSubclassMock(mock.Mock):
+class XenapiMockBase(mock.Mock):
 
     def __init__(self, xenapi_ref):
-        super(_XenapiSubclassMock, self).__init__()
+        super(XenapiMockBase, self).__init__()
         self.__xenapi = xenapi_ref
 
     @property
@@ -325,7 +325,7 @@ class _XenapiSubclassMock(mock.Mock):
         return self.xenapi.session
 
 
-class XenapiNetworkMock(_XenapiSubclassMock):
+class XenapiNetworkMock(XenapiMockBase):
     """
     session.xenapi.network lib mock class.
 
@@ -335,7 +335,7 @@ class XenapiNetworkMock(_XenapiSubclassMock):
     pass
 
 
-class XenapiBondMock(_XenapiSubclassMock):
+class XenapiBondMock(XenapiMockBase):
     """
     session.xenapi.bond lib mock class.
 
@@ -345,7 +345,7 @@ class XenapiBondMock(_XenapiSubclassMock):
     pass
 
 
-class XenapiPIFMock(_XenapiSubclassMock):
+class XenapiPIFMock(XenapiMockBase):
     """
     session.xenapi.pif lib mock class.
 
@@ -371,7 +371,7 @@ class XenapiPIFMock(_XenapiSubclassMock):
         return opaque == management
 
 
-class XenapiPoolMock(_XenapiSubclassMock):
+class XenapiPoolMock(XenapiMockBase):
     """
     session.xenapi.pool lib mock class.
 
@@ -387,7 +387,7 @@ class XenapiPoolMock(_XenapiSubclassMock):
         return self.session.hosts[0].opaque
 
 
-class XenapiHostMock(_XenapiSubclassMock):
+class XenapiHostMock(XenapiMockBase):
     """
     session.xenapi.host lib mock class.
 
@@ -436,7 +436,7 @@ class XenapiHostMock(_XenapiSubclassMock):
         return ""
 
 
-class XenapiHostMetricsMock(_XenapiSubclassMock):
+class XenapiHostMetricsMock(XenapiMockBase):
     """
     session.xenapi.host_metrics lib mock class.
     """
@@ -453,7 +453,7 @@ class XenapiHostMetricsMock(_XenapiSubclassMock):
         return metrics.live
 
 
-class XenapiVMMock(_XenapiSubclassMock):
+class XenapiVMMock(XenapiMockBase):
     """
     session.xenapi.vm lib mock class.
     """


### PR DESCRIPTION
Refactor XenAPIMock* classes to allow unitttest scalabality. Allow multiple session covering diff scenarios.
- Also added unittest to check utils.get_ack_version()
- Once reviewed and merged, more unittests will be added.