### PR TITLE
CA-374074: Fix reset_arp issue

### DIFF
--- a/autocertkit/network_tests.py
+++ b/autocertkit/network_tests.py
@@ -142,17 +142,6 @@ class IperfTest:
         """Ensure that the routing table is setup correctly in the client"""
         log.debug("Configuring routes...")
 
-        # Make a plugin call to ensure the server is going to recieve
-        # packets over the correct interface
-
-        self.plugin_call('reset_arp',
-                         {'vm_ref': self.client, 'mip': self.vm_info[self.client]['ip_m']
-                          })
-
-        self.plugin_call('reset_arp',
-                         {'vm_ref': self.server, 'mip': self.vm_info[self.server]['ip_m']
-                          })
-
         # Make a plugin call to add a route to the client
         self.plugin_call('add_route',
                          {'vm_ref': self.client,
@@ -423,9 +412,6 @@ class VLANTestClass(testbase.NetworkTestClass):
         log.debug("IP address for vm2 is %s" % vm2_ip)
 
         vm2_test_dev, _, vm2_test_ip = get_context_test_ifs(vm2_ref)[0]
-
-        call_ack_plugin(session, 'reset_arp', {'vm_ref': vm1_ref, 'mip': get_context_vm_mip(vm1_ref)})
-        call_ack_plugin(session, 'reset_arp', {'vm_ref': vm2_ref, 'mip': get_context_vm_mip(vm2_ref)})
 
         # Make certain the VMs are available
         for vm_ref in [vm1_ref, vm2_ref]:

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -1225,6 +1225,7 @@ def reset_arp(session, args):
     to send traffic too."""
 
     vm_ref = validate_exists(args, 'vm_ref')
+    mode = validate_exists(args, 'mode', '0', False)
 
     log.debug("Reset ARP for VM %s" % vm_ref)
 
@@ -1260,8 +1261,12 @@ def reset_arp(session, args):
         # Handle the Droid VM case
         vm_m_ip = validate_exists(args, 'mip')
 
+        arp_ignore_value = 1 if mode == '0' else 0
+        rp_filter_value = 0 if mode == '0' else 1
+
         # Global ARP Ignore
-        set_kernel_parameter("net.ipv4.conf.all.arp_ignore", 1, vm_m_ip)
+        set_kernel_parameter("net.ipv4.conf.all.arp_ignore", arp_ignore_value , vm_m_ip)
+        set_kernel_parameter("net.ipv4.conf.default.arp_ignore", arp_ignore_value , vm_m_ip)
 
         '''
         # Revert arp_ignore to default 0, otherwise DLVM (CentOS 7.2) no interface will reply arp query.
@@ -1272,24 +1277,25 @@ def reset_arp(session, args):
         call = [SSH, vm_m_ip, cmd]
         make_local_call(call)
         '''
-        
+
         # In previous DLVM (CentOS 5), rp_filter is 0. If don't set in new DLVM, then Multicast test
         # will be failed using interfaces in same one subnet
         # Change global setting
-        set_kernel_parameter("net.ipv4.conf.all.rp_filter", 0, vm_m_ip)
-        set_kernel_parameter("net.ipv4.conf.default.rp_filter", 0, vm_m_ip)
+        set_kernel_parameter("net.ipv4.conf.all.rp_filter", rp_filter_value, vm_m_ip)
+        set_kernel_parameter("net.ipv4.conf.default.rp_filter", rp_filter_value, vm_m_ip)
+
         # Change current existing interface
         cmd = """ip -o link | awk '{if($2 ~ "eth.+:") print $2}' | sed 's/:$//'"""
         call = [SSH, vm_m_ip, cmd]
         iface_list = make_local_call(call)["stdout"].split()
         for iface in iface_list:
-            config_key = "net.ipv4.conf.%s.rp_filter" % iface
-            set_kernel_parameter(config_key, 0, vm_m_ip)
+            set_kernel_parameter("net.ipv4.conf.%s.arp_ignore" % iface, arp_ignore_value, vm_m_ip)
+            set_kernel_parameter("net.ipv4.conf.%s.rp_filter" % iface, rp_filter_value, vm_m_ip)
 
         # reload sysctl.conf variables
         call = [SSH, vm_m_ip, SYSCTL, "--system"]
         make_local_call(call)
-               
+
         # log arp
         call = [SSH, vm_m_ip, "cat", "/proc/net/arp"]
         make_local_call(call)


### PR DESCRIPTION
In the case of signle subnet, the bonding etc test failed because reset_arp is called only when VM ethx0 enabled and other NIC is missing to config. The solution are
- Set all parameters *.arp_ignore=1
- Move reset_arp call after all VM NICs started

Signed-off-by: Deli Zhang <deli.zhang@citrix.com>