### PR TITLE
CA-382842: Fix issue of "Connection refused"

### DIFF
--- a/autocertkit/common.py
+++ b/autocertkit/common.py
@@ -104,7 +104,10 @@ EOF
 
         with open(f'/tmp/{fcmd}', 'w') as f:
             f.write(cmd)
-        self.put_file(f'/tmp/{fcmd}')
+        res = self.put_file(f'/tmp/{fcmd}')
+        if res['returncode']:
+            os.remove(f'/tmp/{fcmd}')
+            raise Exception(f'{SCP} failed, maybe {self.ip} is not yet ready.')
 
         self.run_cmd(fr'sh {fcmd} >{fout} 2>{ferr}; echo "$?" >{frc}')
 


### PR DESCRIPTION
- If VM network has not yet started completely, ssh to it may encounter failure. Here the fix is raising the exception to let ssh command caller do retry.