### PR TITLE
CP-46833: Fix 'NoneType' object is not subscriptable

### DIFF
--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -757,6 +757,8 @@ __pci_addr_regex = re.compile(
 
 def _is_bus_id(bus_id):
     """ Check given bus_id is format of bus id """
+    if bus_id is None:
+        return False
     return __bus_id_regex.match(bus_id[-7:])
 
 


### PR DESCRIPTION
If get_dev_pci_addr() does not match the __pci_addr_regex in the symlink in /sys/dev/block/* that matches the disk, it returns (-1, None). Nothing in plugins/autocertkit:840 checks for the error and _is_bus_id() blindly indexes its first argument directly: bus_id[-7:]. If bus_id was None, this would have raised an Exception.

Make _is_bus_id() more robust by checking that bus_id is not None before attempting to subscript it.