### PR TITLE
CP-48851: `isAlive` has been removed since python3.8

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -2394,7 +2394,7 @@ def check_test_thread_status(threads):
     """Util function to check if test threads are still active,
     returns True if any are active, else False"""
     for thread in threads:
-        if thread.isAlive():
+        if thread.is_alive():
             time.sleep(10)
             log.debug("Please be patient, the test is still running...")
             thread.join(20)


### PR DESCRIPTION
Use `is_alive` instead to work in XS9 (python3.11)
'is_alive' is also supported in python3.6 which is good for XS8.
https://docs.python.org/3.6/library/threading.html

Test passed: 4009814