### PR TITLE
CP-53745: Update for network renaming feature

### DIFF
--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -168,7 +168,7 @@ def check_files(config):
             assert_file_exists(os.path.join(INSTALL_DIR, config[opt]), label)
 
     for key, value in config['netconf'].items():
-        if key.startswith('eth'):
+        if utils.is_nic_device_name(key):
             vf_driver_pkg = value['vf_driver_pkg']
             if vf_driver_pkg:
                 assert_file_exists(os.path.join(
@@ -212,7 +212,7 @@ def parse_netconf_file(filename):
     cp.read(filename)
     rec = {}
     for section in cp.sections():
-        if section.startswith('eth'):
+        if utils.is_nic_device_name(section):
             parse_section_iface(cp, rec, section)
         elif section == "static_management":
             rec[section] = parse_static_config(cp, section)
@@ -342,7 +342,7 @@ def network_interfaces_to_test(session, config):
     # Extract from netconf the network interfaces that the user
     # has specified.
     ifaces_to_test = [iface.strip() for iface in config['netconf'].keys()
-                      if iface.startswith('eth')]
+                      if utils.is_nic_device_name(iface)]
 
     devices = utils.get_master_network_devices(session)
 
@@ -474,7 +474,7 @@ def pre_flight_checks(session, config):
     recs = config['netconf']
     ifaces = {}
     for k, v in recs.items():
-        if k.startswith('eth'):
+        if utils.is_nic_device_name(k):
             ifaces[k] = v['network_id']
 
     utils.log.debug(

--- a/autocertkit/testbase.py
+++ b/autocertkit/testbase.py
@@ -333,7 +333,7 @@ class TestClass(object):
         log.debug("Netconf: %s" % netconf)
         netid_rec = {}
         for iface, rec in netconf.items():
-            if iface.startswith('eth'):
+            if is_nic_device_name(iface):
                 log.debug("iface: %s Rec: %s" % (iface, rec))
                 nid = rec['network_id']
 
@@ -501,7 +501,7 @@ class NetworkTestClass(TestClass):
         # Construct a list of interface names who have the same physical ID
         # as the provided interface.
 
-        blist = intersection([k for k, v in netconf.items() if k.startswith('eth') and
+        blist = intersection([k for k, v in netconf.items() if is_nic_device_name(k) and
                               v['network_id'] == phy_id],
                              netconf.keys())
 

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -1043,7 +1043,7 @@ def get_hw_offloads_from_core(session, args):
     checking /sys/class/net/ethX """
     eth_dev = validate_exists(args, 'eth_dev')
     if eth_dev.startswith('xenbr'):
-        eth_dev = utils.get_eth_by_bridge(eth_dev)
+        eth_dev = utils.get_eth_by_bridge(session, eth_dev)
 
     rec = {}
     flag = int(make_local_call(
@@ -1337,7 +1337,7 @@ def reset_arp(session, args):
         set_kernel_parameter("net.ipv4.conf.default.rp_filter", rp_filter_value, vm_m_ip)
 
         # Change current existing interface
-        cmd = """ip -o link | awk '{if($2 ~ "en[o|s|p|x][^:]*:" || $2 ~ "eth[^:]*:") print $2}' | sed 's/:$//'"""
+        cmd = """ip -o link | awk '{if($2 ~ "^e.+:") print $2}' | sed 's/:$//'"""
         call = [SSH, vm_m_ip, cmd]
         iface_list = make_local_call(call)["stdout"].split()
         for iface in iface_list:
@@ -1803,7 +1803,7 @@ def mark_local_pif_for_cleanup(session, device):
     # Undo any transformations between bridges/devices that may
     # have taken place already
     if 'xenbr' in device:
-        device = utils.get_eth_by_bridge(device)
+        device = utils.get_eth_by_bridge(session, device)
 
     this_host_uuid = get_from_xensource_inventory('INSTALLATION_UUID')
 

--- a/plugins/autocertkit
+++ b/plugins/autocertkit
@@ -71,6 +71,7 @@ INSTALL_DIR = '/opt/xensource/packages/files/auto-cert-kit'
 if INSTALL_DIR not in sys.path:
     sys.path.insert(0, INSTALL_DIR)
 from common import *
+import utils
 
 
 XE = '/opt/xensource/bin/xe'
@@ -758,7 +759,7 @@ def _pre_tampa_biosdevname():
     pattern = re.compile(r'\d*:?[a-f0-9]+:[a-f0-9]+\.[a-f0-9]')
 
     return [device for device in biosdevobj.devices
-            if (device[type_key].startswith('eth') and pattern.match(device['Bus Info']))]
+            if (utils.is_nic_device_name(device[type_key]) and pattern.match(device['Bus Info']))]
 
 
 def compat_biosdevname():
@@ -1042,7 +1043,7 @@ def get_hw_offloads_from_core(session, args):
     checking /sys/class/net/ethX """
     eth_dev = validate_exists(args, 'eth_dev')
     if eth_dev.startswith('xenbr'):
-        eth_dev = eth_dev.replace('xenbr', 'eth')
+        eth_dev = utils.get_eth_by_bridge(eth_dev)
 
     rec = {}
     flag = int(make_local_call(
@@ -1336,7 +1337,7 @@ def reset_arp(session, args):
         set_kernel_parameter("net.ipv4.conf.default.rp_filter", rp_filter_value, vm_m_ip)
 
         # Change current existing interface
-        cmd = """ip -o link | awk '{if($2 ~ "eth.+:") print $2}' | sed 's/:$//'"""
+        cmd = """ip -o link | awk '{if($2 ~ "en[o|s|p|x][^:]*:" || $2 ~ "eth[^:]*:") print $2}' | sed 's/:$//'"""
         call = [SSH, vm_m_ip, cmd]
         iface_list = make_local_call(call)["stdout"].split()
         for iface in iface_list:
@@ -1802,7 +1803,7 @@ def mark_local_pif_for_cleanup(session, device):
     # Undo any transformations between bridges/devices that may
     # have taken place already
     if 'xenbr' in device:
-        device = device.replace('xenbr', 'eth')
+        device = utils.get_eth_by_bridge(device)
 
     this_host_uuid = get_from_xensource_inventory('INSTALLATION_UUID')
 
@@ -1902,14 +1903,7 @@ def _get_local_device_bridge(session, device):
             return device
 
     log.debug("XAPI does not know bridge of given device %s." % device)
-
-    if device.startswith('eth'):
-        devname = device.replace('eth', 'xenbr')
-        log.debug("Try using %s instead." % devname)
-        return devname
-
     log.debug("Try using device name %s." % device)
-
     return device
 
 


### PR DESCRIPTION
Since XS9, we use the eth name such as 'enp4s0f1' instead of 'ethx'

Tested:
xs8: 4366236
xs9: 4361397 (Use changlei’s private build and manually tested the ack changes)
```
[root@genus-34-55d auto-cert-kit]# ./status.py
0:Finished (Passed:41, Failed:1, Skipped:0)
The one failed case due to a  known issue.
```