### PR TITLE
CA-416185: Skip test cases using bridge as network backend for xs9

### DIFF
--- a/autocertkit/ack_cli.py
+++ b/autocertkit/ack_cli.py
@@ -517,6 +517,11 @@ def main(config, test_run_file):
     config['xs_version'] = utils.get_xenserver_version(session)
     config['xcp_version'] = utils.get_xcp_version(session)
 
+    # Exclude bridge cases as it is not supported since XS9
+    if config['xcp_version'] > utils.XCP_MAX_VER_WITH_BRIDGE:
+        if 'BRIDGE' not in config['exclude']:
+            config['exclude'].append('BRIDGE')
+
     generate_test_config(session, config, test_run_file)
 
     if 'generate' in config:

--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -75,6 +75,9 @@ XCP_MIN_VER_WITH_MULTICAST = "2.3.0"  # XenServer 7.2
 # XCP minimum version with SR-IOV support
 XCP_MIN_VER_WITH_SRIOV = "2.6.0"  # XenServer 7.5
 
+# XCP max version with bridge network backend support
+XCP_MAX_VER_WITH_BRIDGE = "3.4.0"  # XenServer 8.4
+
 # XAPI States
 XAPI_RUNNING_STATE = "Running"
 


### PR DESCRIPTION
bridge is not supported since xs9

4416598 passed