### PR TITLE
CA-426228: Fix race condition in run_xapi_async_tasks

### DIFF
--- a/autocertkit/utils.py
+++ b/autocertkit/utils.py
@@ -1713,10 +1713,21 @@ def run_xapi_async_tasks(session, funcs, timeout=300):
     while task_refs:
         idx, ref = task_refs.pop(0)  # take the first item off
         log.debug("Current Task: %s" % ref)
-        status = session.xenapi.task.get_status(ref)
+        try:
+            status = session.xenapi.task.get_status(ref)
+        except Exception as e:
+            if 'HANDLE_INVALID' in str(e):
+                # Task completed and was garbage-collected by xapi before
+                # we could poll it. Treat as success with empty result.
+                log.debug("Task %s: handle invalid (already completed "
+                          "and GC'd by xapi)" % ref)
+                results.append((idx, ''))
+                continue
+            raise
         if status == "success":
             log.debug("%s has finished" % ref)
             result = session.xenapi.task.get_result(ref)
+            session.xenapi.task.destroy(ref)
 
             log.debug("Result = %s" % result)
             if result.startswith('<value>'):
@@ -1726,8 +1737,9 @@ def run_xapi_async_tasks(session, funcs, timeout=300):
                 results.append((idx, result))
         elif status == "failure":
             # The task has failed, and the error should be propogated upwards.
-            raise Exception("Async call failed with error: %s" %
-                            session.xenapi.task.get_error_info(ref))
+            error_info = session.xenapi.task.get_error_info(ref)
+            session.xenapi.task.destroy(ref)
+            raise Exception("Async call failed with error: %s" % error_info)
         else:
             log.debug("Task Status: %s" % status)
             # task has not finished, so re-attach to list


### PR DESCRIPTION
When multiple async xapi tasks are fired (e.g. VM.start_on), xapi may complete and garbage-collect a task before the polling loop reads its status. This causes task.get_status() to throw HANDLE_INVALID, crashing the test even though the operation succeeded.

2026-04-14 12:17:04,855 auto-cert-kit: ERROR    testbase.py:182        Test Case Failure: test_tx_throughput
2026-04-14 12:17:04,856 auto-cert-kit: DEBUG    testbase.py:183        Traceback (most recent call last):
  File "/opt/xensource/packages/files/auto-cert-kit/testbase.py", line 143, in run_test
    res = getattr(self, test)(self.session)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/xensource/packages/files/auto-cert-kit/network_tests.py", line 766, in test_tx_throughput
    return self._run_test(session, direction)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/xensource/packages/files/auto-cert-kit/network_tests.py", line 1151, in _run_test
    self.ops_test(session, vm_list)
  File "/opt/xensource/packages/files/auto-cert-kit/network_tests.py", line 1325, in ops_test
    start_droid_vms(session, [(master_ref, vm) for vm in vms])
  File "/opt/xensource/packages/files/auto-cert-kit/utils.py", line 1988, in start_droid_vms
    run_xapi_async_tasks(session,
  File "/opt/xensource/packages/files/auto-cert-kit/utils.py", line 1716, in run_xapi_async_tasks
    status = session.xenapi.task.get_status(ref)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/XenAPI.py", line 317, in __call__
    return self.__send(self.__name, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/XenAPI.py", line 198, in xenapi_request
    result = _parse_result(getattr(self, methodname)(*full_params))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/XenAPI.py", line 292, in _parse_result
    raise Failure(result['ErrorDescription'])
XenAPI.Failure: ['HANDLE_INVALID', 'task', 'OpaqueRef:f5f33026-684e-9a42-29f3-533a69e56998']